### PR TITLE
Renamed CloudJS::string() to CloudJS::getString() to avoid Ubuntu GCC build issue

### DIFF
--- a/PotreeConverter/include/CloudJS.hpp
+++ b/PotreeConverter/include/CloudJS.hpp
@@ -42,7 +42,7 @@ public:
 		version = "1.3";
 	}
 
-	string string(){
+	string getString(){
 		stringstream cloudJs;
 
 		cloudJs << "{" << endl;

--- a/PotreeConverter/include/PotreeWriter.h
+++ b/PotreeConverter/include/PotreeWriter.h
@@ -174,7 +174,7 @@ public:
 		}
 
 		ofstream cloudOut(path + "/cloud.js", ios::out);
-		cloudOut << cloudjs.string();
+		cloudOut << cloudjs.getString();
 		cloudOut.close();
 	}
 


### PR DESCRIPTION
This will fix #41 issue.
I tried to replace CloudJS.hpp - `string string(){` to `::string string(){` and `std::string string(){`,
but both didn't fix the issue.
I found the following site, and this seems to be GCC specific issue.
http://stackoverflow.com/questions/12943607/can-a-member-of-a-class-be-named-the-same-name-as-its-type-another-class
So, I replaced `string string(){` to `string getString(){`.
If there is no strong reason to use `string string(){`, I think that this way is the easiest one to fix the issue.
