### PR TITLE
Use the transformation matrix, if present in a VLR.

### DIFF
--- a/PotreeConverter/include/LASPointReader.h
+++ b/PotreeConverter/include/LASPointReader.h
@@ -21,17 +21,46 @@ using std::vector;
 
 
 class LIBLASReader{
+private:
+    double tr[16];
+    bool hasTransform = false;
+    Point transform(double x, double y, double z) const {
+        Point p;
+        if (hasTransform) {
+            p.x = tr[0] * x + tr[4] * y + tr[8] * z + tr[12];
+            p.y = tr[1] * x + tr[5] * y + tr[9] * z + tr[13];
+            p.z = tr[2] * x + tr[6] * y + tr[10] * z + tr[14];
+        } else {
+            p.x = x;
+            p.y = y;
+            p.z = z;
+        }
+        return p;
+    }
 public:
 
 	ifstream stream;
 	liblas::Reader reader;
 
-	LIBLASReader(string path)
-		: stream(path, std::ios::in | std::ios::binary)
-		, reader(liblas::ReaderFactory().CreateWithStream(stream))
-	{
+    LIBLASReader(string path)
+            : stream(path, std::ios::in | std::ios::binary),
+              reader(liblas::ReaderFactory().CreateWithStream(stream)) {
+        std::vector<liblas::VariableRecord> vlrs = reader.GetHeader().GetVLRs();
 
-	}
+//      cout << "There are " << vlrs.size() << " VLRs." << endl;
+        for (int i = 0; i < vlrs.size(); ++i) {
+            liblas::VariableRecord vlr = vlrs[i];
+            if (vlr.GetRecordId() == 2001) {
+                const uint8_t *data = vlr.GetData().data();
+                for (int k = 0; k < 16; ++k) {
+                    memcpy(tr + k, data + (144 + k * 8), sizeof(double));
+                }
+                hasTransform = true;
+                break;
+//                cout << "Found a PTX transformation matrix.\n";
+            }
+        }
+    }
 
 	~LIBLASReader(){
 		if(stream.is_open()){
@@ -39,23 +68,22 @@ public:
 		}
 	}
 
+    Point GetPoint() {
+        liblas::Point const lp = reader.GetPoint();
+        Point p = transform(lp.GetX(), lp.GetY(), lp.GetZ());
+        p.intensity = lp.GetIntensity();
+        p.classification = lp.GetClassification().GetClass();
+
+        p.r = lp.GetColor().GetRed() / 256;
+        p.g = lp.GetColor().GetGreen() / 256;
+        p.b = lp.GetColor().GetBlue() / 256;
+        return p;
+    }
 	void close(){
 		stream.close();
 	}
 
-	AABB getAABB(){
-		AABB aabb;
-
-		const liblas::Header &header = reader.GetHeader();
-
-		Vector3<double> min = Vector3<double>(header.GetMinX(), header.GetMinY(), header.GetMinZ());
-		Vector3<double> max = Vector3<double>(header.GetMaxX(), header.GetMaxY(), header.GetMaxZ());
-		aabb.update(min);
-		aabb.update(max);
-
-		return aabb;
-	}
-
+	AABB getAABB();
 };
 
 
@@ -66,7 +94,6 @@ private:
 	LIBLASReader *reader;
 	vector<string> files;
 	vector<string>::iterator currentFile;
-
 public:
 
 	LASPointReader(string path);

--- a/PotreeConverter/src/LASPointReader.cpp
+++ b/PotreeConverter/src/LASPointReader.cpp
@@ -19,6 +19,22 @@ using std::endl;
 using std::vector;
 using boost::iequals;
 using std::ios;
+using liblas::VariableRecord;
+
+AABB LIBLASReader::getAABB(){
+    AABB aabb;
+
+    const liblas::Header &header = reader.GetHeader();
+
+    Point minp = transform(header.GetMinX(), header.GetMinY(), header.GetMinZ());
+    Vector3<double> min = Vector3<double>(minp.x, minp.y, minp.z);
+    Point maxp = transform(header.GetMaxX(), header.GetMaxY(), header.GetMaxZ());
+    Vector3<double> max = Vector3<double>(maxp.x, maxp.y, maxp.z);
+    aabb.update(min);
+    aabb.update(max);
+
+    return aabb;
+}
 
 LASPointReader::LASPointReader(string path){
 	this->path = path;
@@ -56,6 +72,7 @@ LASPointReader::LASPointReader(string path){
 	// open first file
 	currentFile = files.begin();
 	reader = new LIBLASReader(*currentFile);
+//    cout << "let's go..." << endl;
 }
 
 LASPointReader::~LASPointReader(){
@@ -95,18 +112,8 @@ bool LASPointReader::readNextPoint(){
 }
 
 Point LASPointReader::getPoint(){
-	const liblas::Point &lp = reader->reader.GetPoint();
-	Point p(lp.GetX(), lp.GetY(), lp.GetZ());
-
-	p.intensity = lp.GetIntensity();
-	p.classification = lp.GetClassification().GetClass();
-	
-	p.r = lp.GetColor().GetRed() / 256;
-	p.g = lp.GetColor().GetGreen() / 256;
-	p.b = lp.GetColor().GetBlue() / 256;
-
-
-	return p;
+	Point const p = reader->GetPoint();
+    return p;
 }
 
 AABB LASPointReader::getAABB(){


### PR DESCRIPTION
LAStools can convert PTX files to LAS storing the transformation matrix of the PTS file in a VLR. We need to use this matrix to correctly transform points if we want to load together many LAS files that fave different transorm matrices.
