### PR TITLE
add js-octreedir-prefix option

### DIFF
--- a/PotreeConverter/include/CloudJS.hpp
+++ b/PotreeConverter/include/CloudJS.hpp
@@ -42,12 +42,12 @@ public:
 		version = "1.3";
 	}
 
-	string getString(){
+	string getString(string jsDataPathPrefix){
 		stringstream cloudJs;
-
+    
 		cloudJs << "{" << endl;
 		cloudJs << "\t" << "\"version\": \"" << version << "\"," << endl;
-		cloudJs << "\t" << "\"octreeDir\": \"data\"," << endl;
+		cloudJs << "\t" << "\"octreeDir\": \"" << jsDataPathPrefix << "data\"," << endl;
 		cloudJs << "\t" << "\"boundingBox\": {" << endl;
 		cloudJs << "\t\t" << "\"lx\": " << boundingBox.min.x << "," << endl;
 		cloudJs << "\t\t" << "\"ly\": " << boundingBox.min.y << "," << endl;

--- a/PotreeConverter/include/PotreeConverter.h
+++ b/PotreeConverter/include/PotreeConverter.h
@@ -48,10 +48,11 @@ private:
 	OutputFormat outputFormat;
 
 	float range;
+	string cloudJsOctreeDirPrefix;
 
 public:
 
-	PotreeConverter(vector<string> fData, string workDir, float spacing, int maxDepth, string format, float range, OutputFormat outFormat);
+	PotreeConverter(vector<string> fData, string workDir, float spacing, int maxDepth, string format, float range, string cloudJsOctreeDirPrefix, OutputFormat outFormat);
 
 	void convert();
 

--- a/PotreeConverter/include/PotreeWriter.h
+++ b/PotreeConverter/include/PotreeWriter.h
@@ -82,6 +82,7 @@ public:
 
 	AABB aabb;
 	string path;
+  string jsDataPathPrefix;
 	float spacing;
 	int maxLevel;
 	PotreeWriterNode *root;
@@ -94,11 +95,12 @@ public:
 
 
 
-	PotreeWriter(string path, AABB aabb, float spacing, int maxLevel, OutputFormat outputFormat){
+	PotreeWriter(string path, AABB aabb, float spacing, int maxLevel, string jsDataPathPrefix, OutputFormat outputFormat){
 		this->path = path;
 		this->aabb = aabb;
 		this->spacing = spacing;
 		this->maxLevel = maxLevel;
+    this->jsDataPathPrefix = jsDataPathPrefix;
 		this->outputFormat = outputFormat;
 		numAccepted = 0;
 		pointsInMemory = 0;
@@ -174,7 +176,7 @@ public:
 		}
 
 		ofstream cloudOut(path + "/cloud.js", ios::out);
-		cloudOut << cloudjs.getString();
+		cloudOut << cloudjs.getString(this->jsDataPathPrefix);
 		cloudOut.close();
 	}
 

--- a/PotreeConverter/src/PotreeConverter.cpp
+++ b/PotreeConverter/src/PotreeConverter.cpp
@@ -58,7 +58,7 @@ PointReader *createPointReader(string path){
 	return reader;
 }
 
-PotreeConverter::PotreeConverter(vector<string> sources, string workDir, float spacing, int maxDepth, string format, float range, OutputFormat outFormat){
+PotreeConverter::PotreeConverter(vector<string> sources, string workDir, float spacing, int maxDepth, string format, float range, string cloudJsOctreeDirPrefix, OutputFormat outFormat){
 
 	// if sources contains directories, use files inside the directory instead
 	vector<string> sourceFiles;
@@ -88,6 +88,7 @@ PotreeConverter::PotreeConverter(vector<string> sources, string workDir, float s
 	this->maxDepth = maxDepth;
 	this->format = format;
 	this->range = range;
+  this->cloudJsOctreeDirPrefix = cloudJsOctreeDirPrefix;
 	this->outputFormat = outFormat;
 
 	boost::filesystem::path dataDir(workDir + "/data");
@@ -131,7 +132,7 @@ void PotreeConverter::convert(){
 
 	auto start = high_resolution_clock::now();
 
-	PotreeWriter writer(this->workDir, aabb, spacing, maxDepth, outputFormat);
+	PotreeWriter writer(this->workDir, aabb, spacing, maxDepth, this->cloudJsOctreeDirPrefix, outputFormat);
 	//PotreeWriterLBL writer(this->workDir, aabb, spacing, maxDepth, outputFormat);
 
 	long long pointsProcessed = 0;

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -107,6 +107,7 @@ int main(int argc, char **argv){
 	string format;
 	float range;
 	string outFormatString;
+  string cloudJsOctreeDirPrefix;
 	OutputFormat outFormat;
 
 	cout.imbue(std::locale(""));
@@ -121,6 +122,7 @@ int main(int argc, char **argv){
 			("levels,l", po::value<int>(&levels), "Number of levels that will be generated. 0: only root, 1: root and its children, ...")
 			("input-format,f", po::value<string>(&format), "Input format. xyz: cartesian coordinates as floats, rgb: colors as numbers, i: intensity as number")
 			("range,r", po::value<float>(&range), "Range of rgb or intensity. ")
+			("js-octreedir-prefix,p", po::value<string>(&cloudJsOctreeDirPrefix), "Prefix to be pre-pended to \"octreeDir\" value in \"cloud.js\"")
 			("output-format", po::value<string>(&outFormatString), "Output format can be BINARY, LAS or LAZ. Default is BINARY")
 			("source", po::value<std::vector<std::string> >(), "Source file. Can be LAS, LAZ or PLY");
 		po::positional_options_description p; 
@@ -150,6 +152,7 @@ int main(int argc, char **argv){
 		if(!vm.count("levels")) levels = 3;
 		if(!vm.count("input-format")) format = "xyzrgb";
 		if(!vm.count("range")) range = 255;
+		if(!vm.count("js-octreedir-prefix")) cloudJsOctreeDirPrefix = "";
 		if(!vm.count("output-format")) outFormatString = "BINARY";
 		if(outFormatString == "BINARY"){
 			outFormat = OutputFormat::BINARY;
@@ -168,6 +171,7 @@ int main(int argc, char **argv){
 		cout << "levels: " << levels << endl;
 		cout << "format: " << format << endl;
 		cout << "range: " << range << endl;
+		cout << "js-octreedir-prefix: " << cloudJsOctreeDirPrefix << endl;
 		cout << "output-format: " << outFormatString << endl;
 		cout << endl;
 	}catch(exception &e){
@@ -179,7 +183,7 @@ int main(int argc, char **argv){
 	auto start = high_resolution_clock::now();
 	
 	try{
-		PotreeConverter pc(source, outdir, spacing, levels, format, range, outFormat);
+		PotreeConverter pc(source, outdir, spacing, levels, format, range, cloudJsOctreeDirPrefix, outFormat);
 		pc.convert();
 	}catch(exception &e){
 		cout << "ERROR: " << e.what() << endl;


### PR DESCRIPTION
Lets you add a prefix option to the cloud.js data directory for variations in html hosting

Example: `-p js/scene/`
