### PR TITLE
Created a tiling phase.

### DIFF
--- a/PotreeConverter/include/PotreeConverter.h
+++ b/PotreeConverter/include/PotreeConverter.h
@@ -46,6 +46,7 @@ private:
 	int maxDepth;
 	string format;
 	OutputFormat outputFormat;
+	bool printFileName;
 
 	float range;
 	double scale;
@@ -53,7 +54,7 @@ private:
 
 public:
 
-	PotreeConverter(vector<string> fData, string workDir, float spacing, int diagonalFraction, int maxDepth, string format, float range, double scale, OutputFormat outFormat);
+	PotreeConverter(vector<string> fData, string workDir, float spacing, int diagonalFraction, int maxDepth, string format, float range, double scale, OutputFormat outFormat, bool printFileName);
 
 	void convert();
 

--- a/PotreeConverter/include/PotreeTiler.h
+++ b/PotreeConverter/include/PotreeTiler.h
@@ -1,0 +1,38 @@
+#ifndef POTREE_TILER_H
+#define POTREE_TILER_H
+
+#include "AABB.h"
+#include "definitions.hpp"
+
+#include <string>
+#include <vector>
+#include <sstream>
+#include <map>
+#include <cstdint>
+
+class SparseGrid;
+
+
+using std::vector;
+using std::string;
+using std::stringstream;
+using std::map;
+
+class PotreeTiler {
+
+private:
+    vector<string> sources;
+    string workDir;
+    float spacing;
+    string format;
+    double scale;
+
+public:
+
+    PotreeTiler(vector<string> fData, string workDir, float spacing, string format, double scale);
+
+    void tile();
+};
+
+
+#endif

--- a/PotreeConverter/include/PotreeTiler.h
+++ b/PotreeConverter/include/PotreeTiler.h
@@ -24,12 +24,11 @@ private:
     vector<string> sources;
     string workDir;
     float spacing;
-    string format;
     double scale;
 
 public:
 
-    PotreeTiler(vector<string> fData, string workDir, float spacing, string format, double scale);
+    PotreeTiler(vector<string> fData, string workDir, float spacing, double scale);
 
     void tile();
 };

--- a/PotreeConverter/include/TilingGrid.h
+++ b/PotreeConverter/include/TilingGrid.h
@@ -35,6 +35,8 @@ public:
 	~TilingGrid();
 
 	void add(Point &point);
+
+	void flush();
 };
 
 

--- a/PotreeConverter/include/TilingGrid.h
+++ b/PotreeConverter/include/TilingGrid.h
@@ -1,0 +1,42 @@
+
+
+#ifndef TILING_GRID_H
+#define TILING_GRID_H
+
+#include "AABB.h"
+#include "Point.h"
+#include "GridIndex.h"
+#include "GridCell.h"
+#include "LASPointWriter.hpp"
+
+#include <map>
+#include <vector>
+#include <math.h>
+
+using std::vector;
+using std::map;
+using std::min;
+using std::max;
+
+#define MAX_FLOAT std::numeric_limits<float>::max()
+
+class TilingGrid : public map<GridIndex, LASPointWriter*>{
+public:
+	float spacing;
+	int numAccepted;
+	double scale;
+	string tilesDir;
+
+	TilingGrid(float spacing, double scale, string tilesDir);
+
+	TilingGrid(const TilingGrid &other)
+		: spacing(other.spacing), numAccepted(other.numAccepted), tilesDir(other.tilesDir) {}
+
+	~TilingGrid();
+
+	void add(Point &point);
+};
+
+
+
+#endif

--- a/PotreeConverter/include/TilingGrid.h
+++ b/PotreeConverter/include/TilingGrid.h
@@ -1,26 +1,13 @@
-
-
 #ifndef TILING_GRID_H
 #define TILING_GRID_H
 
-#include "AABB.h"
-#include "Point.h"
-#include "GridIndex.h"
-#include "GridCell.h"
-#include "LASPointWriter.hpp"
-
 #include <map>
-#include <vector>
-#include <math.h>
-
-using std::vector;
-using std::map;
-using std::min;
-using std::max;
+#include "GridIndex.h"
+#include "LASPointWriter.hpp"
 
 #define MAX_FLOAT std::numeric_limits<float>::max()
 
-class TilingGrid : public map<GridIndex, LASPointWriter*>{
+class TilingGrid : public std::map<GridIndex, LASPointWriter*>{
 public:
 	float spacing;
 	int numAccepted;
@@ -38,7 +25,5 @@ public:
 
 	void flush();
 };
-
-
 
 #endif

--- a/PotreeConverter/include/stuff.h
+++ b/PotreeConverter/include/stuff.h
@@ -19,6 +19,7 @@
 #include "GridIndex.h"
 #include "SparseGrid.h"
 #include "GridCell.h"
+#include "PointReader.h"
 
 using std::ifstream;
 using std::ofstream;
@@ -87,5 +88,9 @@ bool endsWith (std::string const &fullString, std::string const &ending);
  * see http://stackoverflow.com/questions/735204/convert-a-string-in-c-to-upper-case
  */
 string toUpper(string str);
+
+PointReader *createPointReader(string path);
+
+AABB calculateAABB(vector<string> sources);
 
 #endif

--- a/PotreeConverter/src/PotreeTiler.cpp
+++ b/PotreeConverter/src/PotreeTiler.cpp
@@ -1,0 +1,107 @@
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
+#include "PotreeTiler.h"
+#include "stuff.h"
+#include "PotreeException.h"
+#include "PotreeWriter.h"
+#include "LASPointWriter.hpp"
+
+#include <chrono>
+#include <sstream>
+#include <string>
+#include <map>
+#include <vector>
+#include <math.h>
+#include <fstream>
+#include "TilingGrid.h"
+
+using std::stringstream;
+using std::map;
+using std::string;
+using std::vector;
+using std::find;
+using std::chrono::high_resolution_clock;
+using std::chrono::milliseconds;
+using std::chrono::duration_cast;
+using std::fstream;
+using boost::iends_with;
+using boost::filesystem::is_directory;
+using boost::filesystem::directory_iterator;
+using boost::filesystem::is_regular_file;
+using boost::filesystem::path;
+
+PotreeTiler::PotreeTiler(vector<string> sources, string workDir, float spacing, string format,
+         double scale) {
+    // if sources contains directories, use files inside the directory instead
+    vector<string> sourceFiles;
+    for (int i = 0; i < sources.size(); i++) {
+        string source = sources[i];
+        path pSource(source);
+        if (boost::filesystem::is_directory(pSource)) {
+            boost::filesystem::directory_iterator it(pSource);
+            for (; it != boost::filesystem::directory_iterator(); it++) {
+                path pDirectoryEntry = it->path();
+                if (boost::filesystem::is_regular_file(pDirectoryEntry)) {
+                    string filepath = pDirectoryEntry.string();
+                    if (boost::iends_with(filepath, ".las") || boost::iends_with(filepath, ".laz") || boost::iends_with(filepath, ".ply")) {
+                        sourceFiles.push_back(filepath);
+                    }
+                }
+            }
+        } else if (boost::filesystem::is_regular_file(pSource)) {
+            sourceFiles.push_back(source);
+        }
+    }
+
+    this->sources = sourceFiles;
+    this->workDir = workDir;
+    this->spacing = spacing;
+    this->format = format;
+    this->scale = scale;
+
+    boost::filesystem::path tilesDir(workDir + "/tiles");
+    boost::filesystem::create_directories(tilesDir);
+}
+
+void PotreeTiler::tile() {
+    auto start = high_resolution_clock::now();
+
+    TilingGrid grid(spacing, scale, workDir + "/tiles");
+
+    long long pointsProcessed = 0;
+    for (int i = 0; i < sources.size(); i++) {
+        string source = sources[i];
+        cout << "tiling " << source << endl;
+
+        PointReader *reader = createPointReader(source);
+        while (reader->readNextPoint()) {
+            pointsProcessed++;
+            //if((pointsProcessed%50) != 0){
+            //	continue;
+            //}
+
+            Point p = reader->getPoint();
+            grid.add(p);
+
+            if ((pointsProcessed % 1000000) == 0) {
+                cout << (pointsProcessed / 1000000) << "m points in ";
+                auto end = high_resolution_clock::now();
+                long duration = duration_cast<milliseconds>(end - start).count();
+                cout << (duration / 1000.0f) << "s" << endl;
+                //return;
+            }
+        }
+        reader->close();
+        delete reader;
+    }
+
+//	cout << writer.numAccepted << " points written" << endl;
+
+    auto end = high_resolution_clock::now();
+    long duration = duration_cast<milliseconds>(end - start).count();
+    cout << "duration: " << (duration / 1000.0f) << "s" << endl;
+
+    cout << "closing writer" << endl;
+//	writer.close();
+}

--- a/PotreeConverter/src/PotreeTiler.cpp
+++ b/PotreeConverter/src/PotreeTiler.cpp
@@ -32,7 +32,7 @@ using boost::filesystem::is_regular_file;
 using boost::filesystem::path;
 
 PotreeTiler::PotreeTiler(vector<string> sources, string workDir, float spacing, string format,
-         double scale) {
+        double scale) {
     // if sources contains directories, use files inside the directory instead
     vector<string> sourceFiles;
     for (int i = 0; i < sources.size(); i++) {
@@ -89,6 +89,8 @@ void PotreeTiler::tile() {
                 auto end = high_resolution_clock::now();
                 long duration = duration_cast<milliseconds>(end - start).count();
                 cout << (duration / 1000.0f) << "s" << endl;
+                if ((pointsProcessed % 10000000) == 0)
+                    grid.flush();
                 //return;
             }
         }

--- a/PotreeConverter/src/PotreeTiler.cpp
+++ b/PotreeConverter/src/PotreeTiler.cpp
@@ -31,8 +31,7 @@ using boost::filesystem::directory_iterator;
 using boost::filesystem::is_regular_file;
 using boost::filesystem::path;
 
-PotreeTiler::PotreeTiler(vector<string> sources, string workDir, float spacing, string format,
-        double scale) {
+PotreeTiler::PotreeTiler(vector<string> sources, string workDir, float spacing, double scale) {
     // if sources contains directories, use files inside the directory instead
     vector<string> sourceFiles;
     for (int i = 0; i < sources.size(); i++) {
@@ -57,7 +56,6 @@ PotreeTiler::PotreeTiler(vector<string> sources, string workDir, float spacing, 
     this->sources = sourceFiles;
     this->workDir = workDir;
     this->spacing = spacing;
-    this->format = format;
     this->scale = scale;
 
     boost::filesystem::path tilesDir(workDir + "/tiles");
@@ -98,6 +96,8 @@ void PotreeTiler::tile() {
         delete reader;
     }
 
+    grid.flush();
+
 //	cout << writer.numAccepted << " points written" << endl;
 
     auto end = high_resolution_clock::now();
@@ -105,5 +105,4 @@ void PotreeTiler::tile() {
     cout << "duration: " << (duration / 1000.0f) << "s" << endl;
 
     cout << "closing writer" << endl;
-//	writer.close();
 }

--- a/PotreeConverter/src/TilingGrid.cpp
+++ b/PotreeConverter/src/TilingGrid.cpp
@@ -11,10 +11,7 @@ TilingGrid::TilingGrid(float spacing, double scale, string tilesDir) {
 }
 
 TilingGrid::~TilingGrid() {
-    TilingGrid::iterator it;
-    for (it = begin(); it != end(); it++) {
-        delete it->second;
-    }
+    flush();
 }
 
 void TilingGrid::add(Point &point) {
@@ -33,4 +30,12 @@ void TilingGrid::add(Point &point) {
         this->operator[](index) = new LASPointWriter(fileName, myAABB, scale);
     }
     this->operator[](index)->write(point);
+}
+
+void TilingGrid::flush() {
+    TilingGrid::iterator it;
+    for (it = begin(); it != end(); it++) {
+        delete it->second;
+    }
+    this->clear();
 }

--- a/PotreeConverter/src/TilingGrid.cpp
+++ b/PotreeConverter/src/TilingGrid.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <stuff.h>
+
+#include "TilingGrid.h"
+
+TilingGrid::TilingGrid(float spacing, double scale, string tilesDir) {
+    this->spacing = spacing;
+    this->scale = scale;
+    this->tilesDir = tilesDir;
+    numAccepted = 0;
+}
+
+TilingGrid::~TilingGrid() {
+    TilingGrid::iterator it;
+    for (it = begin(); it != end(); it++) {
+        delete it->second;
+    }
+}
+
+void TilingGrid::add(Point &point) {
+    int nx = (int) (point.x / spacing);
+    int ny = (int) (point.y / spacing);
+    int nz = (int) (point.z / spacing);
+
+    GridIndex index(nx, ny, nz);
+    if (find(index) == end()) {
+        AABB myAABB(Vector3<double>(nx * spacing, ny * spacing, nz * spacing),
+                Vector3<double>((nx + 1) * spacing, (ny + 1) * spacing, (nz + 1) * spacing));
+        string fileName = tilesDir + "/t_" +
+                boost::lexical_cast<std::string>(nx) + "_" +
+                boost::lexical_cast<std::string>(ny) + "_" +
+                boost::lexical_cast<std::string>(nz) + ".las";
+        this->operator[](index) = new LASPointWriter(fileName, myAABB, scale);
+    }
+    this->operator[](index)->write(point);
+}

--- a/PotreeConverter/src/TilingGrid.cpp
+++ b/PotreeConverter/src/TilingGrid.cpp
@@ -1,6 +1,5 @@
-#include <iostream>
-#include <stuff.h>
-
+#include <ostream>
+using std::ostream;
 #include "TilingGrid.h"
 
 TilingGrid::TilingGrid(float spacing, double scale, string tilesDir) {
@@ -33,8 +32,7 @@ void TilingGrid::add(Point &point) {
 }
 
 void TilingGrid::flush() {
-    TilingGrid::iterator it;
-    for (it = begin(); it != end(); it++) {
+    for (TilingGrid::iterator it = begin(); it != end(); it++) {
         delete it->second;
     }
     this->clear();

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -198,7 +198,7 @@ int main(int argc, char **argv){
 	try{
 		if(0.0 != tile) {
 			cout << "Tiling the cloud with spacing: " << tile << endl;
-			PotreeTiler tiler(source, outdir, tile, format, scale);
+			PotreeTiler tiler(source, outdir, tile, scale);
 			tiler.tile();
 			cout << "Tiling done." << endl;
 			std::vector<string> tilepath;

--- a/PotreeConverter/src/stuff.cpp
+++ b/PotreeConverter/src/stuff.cpp
@@ -9,6 +9,8 @@
 //#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <PlyPointReader.h>
+#include <LASPointReader.h>
 
 #include "Vector3.h"
 #include "AABB.h"
@@ -204,4 +206,35 @@ string toUpper(string str){
 	std::transform(tmp.begin(), tmp.end(),tmp.begin(), ::toupper);
 
 	return tmp;
+}
+
+PointReader *createPointReader(string path){
+	PointReader *reader = NULL;
+	if(boost::iends_with(path, ".las") || boost::iends_with(path, ".laz")){
+		reader = new LASPointReader(path);
+	}else if(boost::iends_with(path, ".ply")){
+		reader = new PlyPointReader(path);
+	}
+
+	return reader;
+}
+
+AABB calculateAABB(vector<string> sources){
+	AABB aabb;
+
+	for(int i = 0; i < sources.size(); i++){
+		string source = sources[i];
+
+		PointReader *reader = createPointReader(source);
+		AABB lAABB = reader->getAABB();
+
+
+		aabb.update(lAABB.min);
+		aabb.update(lAABB.max);
+
+		reader->close();
+		delete reader;
+	}
+
+	return aabb;
 }


### PR DESCRIPTION
Hi. I created a PotreeTiler. Using the -t parameter, the normal indexing phase is preceded by a tiling phase that tiles the cloud in the /tiles subdirectory of the output dir. After this phase, the PotreeConverter is run on these new tile files instead than on the original files.
The tiles are created as LAS, and they are not deleted at the end.
I tested it on a 32m cloud, and it lowered the memory usage from 1.9GiB to 670 MiB, while raising the runtime from 360s to 450s.