### PR TITLE
Created a PTX file reader.

### DIFF
--- a/PotreeConverter/include/PTXPointReader.h
+++ b/PotreeConverter/include/PTXPointReader.h
@@ -1,20 +1,10 @@
 #ifndef PTXPOINTREADER_H
 #define PTXPOINTREADER_H
 
-#include <string>
-#include <iostream>
-#include <vector>
-
-#include <liblas/liblas.hpp>
-
-#include "Point.h"
 #include "PointReader.h"
 
 using std::string;
-
 using std::fstream;
-using std::cout;
-using std::endl;
 using std::vector;
 
 /**
@@ -26,9 +16,7 @@ class PTXPointReader : public PointReader {
 private:
     double tr[16];
     long count;
-    long currentPointInChunk;
     Point p;
-    long pointsInCurrentChunk;
     long currentChunk;
     bool hasAABB = false;
 

--- a/PotreeConverter/include/PTXPointReader.h
+++ b/PotreeConverter/include/PTXPointReader.h
@@ -1,0 +1,88 @@
+#ifndef PTXPOINTREADER_H
+#define PTXPOINTREADER_H
+
+#include <string>
+#include <iostream>
+#include <vector>
+
+#include <liblas/liblas.hpp>
+
+#include "Point.h"
+#include "PointReader.h"
+
+using std::string;
+
+using std::fstream;
+using std::cout;
+using std::endl;
+using std::vector;
+
+/**
+* This reader importa PTX files. We suppose that PTX files are a concatenation,
+* of multiple PTX "chunks", all of them having the same structure. Every point
+* has exactly 4 double precision fields: X, Y, Z, Intensity (from 0.0 to 1.0).
+*/
+class PTXPointReader : public PointReader {
+private:
+    double tr[16];
+    long count;
+    long currentPointInChunk;
+    Point p;
+    long pointsInCurrentChunk;
+    long currentChunk;
+    bool hasAABB = false;
+
+    inline Point transform(double x, double y, double z) const {
+        Point p(tr[0] * x + tr[4] * y + tr[8] * z + tr[12],
+                tr[1] * x + tr[5] * y + tr[9] * z + tr[13],
+                tr[2] * x + tr[6] * y + tr[10] * z + tr[14]);
+        return p;
+    }
+
+    fstream stream;
+    AABB aabb;
+    string path;
+    vector<string> files;
+    vector<string>::iterator currentFile;
+
+    /**
+    * Returns false if there is neo next chunk.
+    */
+    bool loadChunk();
+
+    void scanForAABB();
+
+    bool doReadNextPoint();
+
+public:
+
+    PTXPointReader(string path);
+
+    ~PTXPointReader() {
+        close();
+    }
+
+    bool readNextPoint();
+
+    inline Point getPoint() {
+        return p;
+    }
+
+    inline AABB getAABB() {
+        if(!hasAABB) {
+            scanForAABB();
+            hasAABB = true;
+        }
+        return aabb;
+    }
+
+    inline long numPoints() {
+        return count;
+    }
+
+    inline void close() {
+        stream.close();
+    }
+};
+
+#endif

--- a/PotreeConverter/src/PTXPointReader.cpp
+++ b/PotreeConverter/src/PTXPointReader.cpp
@@ -112,6 +112,7 @@ void PTXPointReader::scanForAABB() {
 bool PTXPointReader::loadChunk() {
     long rows, cols;
     double dummy;
+    cout << "Loading a new PTX chunk: " << this->currentChunk << endl;
 
     this->currentPointInChunk = 0;
     this->stream >> cols >> rows;

--- a/PotreeConverter/src/PTXPointReader.cpp
+++ b/PotreeConverter/src/PTXPointReader.cpp
@@ -19,6 +19,9 @@ using std::vector;
 using boost::iequals;
 using std::ios;
 
+static const int COORD_THRESHOLD = 10000;
+static const int INVALID_INTENSITY = 32767;
+
 /**
 * The constructor needs to scan the whole PTX file to find out the bounding box. Unluckily.
 * TODO: during the scan all the points are read and transformed. Afterwards, during loading
@@ -134,7 +137,7 @@ bool PTXPointReader::readNextPoint() {
         bool result = doReadNextPoint();
         if (!result)
             return false;
-        if (32767 != p.intensity)
+        if (INVALID_INTENSITY != p.intensity)
             return true;
     }
     return false;
@@ -163,6 +166,9 @@ bool PTXPointReader::doReadNextPoint() {
     this->stream >> x >> y >> z >> i;
     this->currentPointInChunk++;
     this->p = transform(x, y, z);
-    this->p.intensity = 65535.0 * i;
+    if (x > COORD_THRESHOLD || y > COORD_THRESHOLD || z > COORD_THRESHOLD)
+        this->p.intensity = INVALID_INTENSITY;
+    else
+        this->p.intensity = 65535.0 * i;
     return true;
 }

--- a/PotreeConverter/src/PTXPointReader.cpp
+++ b/PotreeConverter/src/PTXPointReader.cpp
@@ -1,0 +1,167 @@
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "boost/filesystem.hpp"
+#include <boost/algorithm/string.hpp>
+#include <term.h>
+
+#include "PTXPointReader.h"
+
+
+namespace fs = boost::filesystem;
+
+using std::ifstream;
+using std::fstream;
+using std::cout;
+using std::endl;
+using std::vector;
+using boost::iequals;
+using std::ios;
+
+/**
+* The constructor needs to scan the whole PTX file to find out the bounding box. Unluckily.
+* TODO: during the scan all the points are read and transformed. Afterwards, during loading
+* the points are read again and transformed again. It should be nice to save the
+* transformed points in a temporary file. That would mean a LAS file or something similar.
+* Unuseful. It's better to convert the PTX to LAS files.
+* TODO: it seems theat the PTXPointReader is asked to produce the bounding box more than once.
+* Maybe it should be saved somewhere. Chez moi, scanning 14m points needs 90 secs. The
+* process speed of the PTX file is about 1m points every 50 secs.
+*/
+PTXPointReader::PTXPointReader(string path) {
+    this->path = path;
+
+    if (fs::is_directory(path)) {
+        // if directory is specified, find all ptx files inside directory
+
+        for (fs::directory_iterator it(path); it != fs::directory_iterator(); it++) {
+            fs::path filepath = it->path();
+            if (fs::is_regular_file(filepath)) {
+                if (iequals(fs::extension(filepath), ".ptx")) {
+                    files.push_back(filepath.string());
+                }
+            }
+        }
+    } else {
+        files.push_back(path);
+    }
+
+    // open first file
+    this->currentFile = files.begin();
+    stream = fstream(*(this->currentFile), ios::in);
+    this->currentChunk = 0;
+    loadChunk();
+
+//    cout << "let's go..." << endl;
+}
+
+void PTXPointReader::scanForAABB() {
+    // read bounding box
+    double x, y, z, dummy, minx, miny, minz, maxx, maxy, maxz, intensity;
+    bool firstPoint = true;
+    bool pleaseStop = false;
+    this->count = 0;
+    cout << "PTXPointReader: scanning points for AABB." << endl;
+    for (int i = 0; i < files.size(); i++) {
+        this->stream = fstream(files[i], ios::in);
+        this->currentChunk = 0;
+        while (!pleaseStop) {
+            cout << "PTXPointReader: scanning " << files[i] << " chunk " << currentChunk << endl;
+            if (!loadChunk()) {
+                break;
+            }
+            for (int j = 0; j < this->pointsInCurrentChunk; j++) {
+                this->stream >> x >> y >> z >> intensity;
+                if (0.5 != intensity) {
+                    Point p = transform(x, y, z);
+                    if (firstPoint) {
+                        maxx = minx = p.x;
+                        maxy = miny = p.y;
+                        maxz = minz = p.z;
+                        firstPoint = false;
+                    } else {
+                        minx = p.x < minx ? p.x : minx;
+                        maxx = p.x > maxx ? p.x : maxx;
+                        miny = p.y < miny ? p.y : miny;
+                        maxy = p.y > maxy ? p.y : maxy;
+                        minz = p.z < minz ? p.z : minz;
+                        maxz = p.z > maxz ? p.z : maxz;
+                    }
+                    this->count++;
+                    if (0 == this->count % 1000000)
+                        cout << "PTXPointReader: scanned " << count / 1000000 << "m points.\n";
+                }
+            }
+            if (this->stream.eof()) {
+                pleaseStop = true;
+                break;
+            }
+            this->currentChunk++;
+        }
+        this->stream.close();
+    }
+
+    cout << "PTXPointReader: scanning points for AABB done." << endl;
+
+    AABB lAABB(Vector3<double>(minx, miny, minz), Vector3<double>(maxx, maxy, maxz));
+    aabb.update(lAABB.min);
+    aabb.update(lAABB.max);
+}
+
+bool PTXPointReader::loadChunk() {
+    long rows, cols;
+    double dummy;
+
+    this->currentPointInChunk = 0;
+    this->stream >> cols >> rows;
+    if (this->stream.eof())
+        return false;
+    this->pointsInCurrentChunk = cols * rows;
+    for (int j = 0; j < 4; j++) {
+        this->stream >> dummy >> dummy >> dummy;
+    }
+    this->stream >> tr[0] >> tr[1] >> tr[2] >> tr[3]
+            >> tr[4] >> tr[5] >> tr[6] >> tr[7]
+            >> tr[8] >> tr[9] >> tr[10] >> tr[11]
+            >> tr[12] >> tr[13] >> tr[14] >> tr[15];
+    return true;
+}
+
+bool PTXPointReader::readNextPoint() {
+    while (true) {
+        bool result = doReadNextPoint();
+        if (!result)
+            return false;
+        if (32767 != p.intensity)
+            return true;
+    }
+    return false;
+}
+
+bool PTXPointReader::doReadNextPoint() {
+    if (this->currentPointInChunk == this->pointsInCurrentChunk) {
+        if (this->stream.eof()) {
+            this->stream.close();
+            this->currentFile++;
+            this->currentPointInChunk = 0;
+
+            if (this->currentFile != files.end()) {
+                this->stream = fstream(*(this->currentFile), ios::in);
+                this->currentChunk = 0;
+                loadChunk();
+            } else {
+                return false;
+            }
+        } else {
+            this->currentChunk++;
+            loadChunk();
+        }
+    }
+    double x, y, z, i;
+    this->stream >> x >> y >> z >> i;
+    this->currentPointInChunk++;
+    this->p = transform(x, y, z);
+    this->p.intensity = 65535.0 * i;
+    return true;
+}

--- a/PotreeConverter/src/PotreeConverter.cpp
+++ b/PotreeConverter/src/PotreeConverter.cpp
@@ -6,9 +6,9 @@
 #include "PotreeConverter.h"
 #include "stuff.h"
 #include "LASPointReader.h"
+#include "PTXPointReader.h"
 #include "PotreeException.h"
 #include "PotreeWriter.h"
-#include "LASPointReader.h"
 #include "LASPointWriter.hpp"
 #include "PlyPointReader.h"
 
@@ -51,6 +51,8 @@ PointReader *createPointReader(string path){
 	PointReader *reader = NULL;
 	if(boost::iends_with(path, ".las") || boost::iends_with(path, ".laz")){
 		reader = new LASPointReader(path);
+	}else if(boost::iends_with(path, ".ptx")){
+		reader = new PTXPointReader(path);
 	}else if(boost::iends_with(path, ".ply")){
 		reader = new PlyPointReader(path);
 	}
@@ -71,7 +73,7 @@ PotreeConverter::PotreeConverter(vector<string> sources, string workDir, float s
 				path pDirectoryEntry = it->path();
 				if(boost::filesystem::is_regular_file(pDirectoryEntry)){
 					string filepath = pDirectoryEntry.string();
-					if(boost::iends_with(filepath, ".las") || boost::iends_with(filepath, ".laz") || boost::iends_with(filepath, ".ply")){
+					if(boost::iends_with(filepath, ".las") || boost::iends_with(filepath, ".laz") || boost::iends_with(filepath, ".ptx") || boost::iends_with(filepath, ".ply")){
 						sourceFiles.push_back(filepath);
 					}
 				}

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -126,7 +126,7 @@ int main(int argc, char **argv){
 			("range,r", po::value<float>(&range), "Range of rgb or intensity. ")
 			("output-format", po::value<string>(&outFormatString), "Output format can be BINARY, LAS or LAZ. Default is BINARY")
 			("scale", po::value<double>(&scale), "Scale of the X, Y, Z coordinate in LAS and LAZ files.")
-			("source", po::value<std::vector<std::string> >(), "Source file. Can be LAS, LAZ or PLY");
+			("source", po::value<std::vector<std::string> >(), "Source file. Can be LAS, LAZ, PTX or PLY");
 		po::positional_options_description p; 
 		p.add("source", -1); 
 


### PR DESCRIPTION
This is a PTX file reader. It has the quasi-obvious limitation that it needs to scan the full file to have the bounding box.
Used together with the tiling patch it allows to index a pointcloud directly from PTX files, without the need for txt2las or lastile.
By now it is not useful without the tiling phase, because each ptx file will be scanned many times only to have its bounding box during indicization.