### PR TITLE
Fixing leak in LASPointWriter.

### DIFF
--- a/PotreeConverter/include/LASPointWriter.hpp
+++ b/PotreeConverter/include/LASPointWriter.hpp
@@ -88,6 +88,8 @@ public:
 			stream->close();
 			delete stream;
 			stream = NULL;
+
+			delete header;
 		}
 
 	}

--- a/PotreeConverter/include/LASPointWriter.hpp
+++ b/PotreeConverter/include/LASPointWriter.hpp
@@ -89,7 +89,11 @@ public:
 			delete stream;
 			stream = NULL;
 
+		}
+
+		if(header != NULL) {
 			delete header;
+			header = NULL;
 		}
 
 	}


### PR DESCRIPTION
Hi. It seems to me that we need to delete header also. I am working on tiling clouds into LAS files, and I found my memory full of dandgling LAS headers.

Thank-you.