### PR TITLE
Better intensity conversion in PTXPointReader.

### DIFF
--- a/PotreeConverter/src/PTXPointReader.cpp
+++ b/PotreeConverter/src/PTXPointReader.cpp
@@ -231,7 +231,7 @@ bool PTXPointReader::doReadNextPoint() {
     unsigned long size1 = split.size();
     if (size1 > 3) {
         this->p = transform(tr, split[0], split[1], split[2]);
-        double sqrtIntensity = sqrt(split[3]);
+        double sqrtIntensity = log(split[3] * 1.71828182846 + 1);
         this->p.intensity = 65535.0 * sqrtIntensity;
         this->p.a = 0;
         if (4 == size1) {

--- a/PotreeConverter/src/PTXPointReader.cpp
+++ b/PotreeConverter/src/PTXPointReader.cpp
@@ -231,11 +231,11 @@ bool PTXPointReader::doReadNextPoint() {
     unsigned long size1 = split.size();
     if (size1 > 3) {
         this->p = transform(tr, split[0], split[1], split[2]);
-        double sqrtIntensity = log(split[3] * 1.71828182846 + 1);
-        this->p.intensity = 65535.0 * sqrtIntensity;
+        double intensity = split[3];
+        this->p.intensity = 65535.0 * intensity;
         this->p.a = 0;
         if (4 == size1) {
-            this->p.r = this->p.g = this->p.b = sqrtIntensity * 255.0;
+            this->p.r = this->p.g = this->p.b = intensity * 255.0;
         } else if (7 == size1) {
             this->p.r = split[4];
             this->p.g = split[5];


### PR DESCRIPTION
Currently the PTX reader transforms the intensity using sqrt to brighten middle tones. It is a bit too bright. The logarithm approximates better the human perception.