### PR TITLE
Optimization: empty datafiles and cloud.js are created only at the end.

### DIFF
--- a/PotreeConverter/include/PotreeWriterDartThrowing.h
+++ b/PotreeConverter/include/PotreeWriterDartThrowing.h
@@ -158,6 +158,16 @@ public:
 			flush();
 		}
 	}
+    
+    void flushThread() {
+        
+    }
+    
+    void addToFlushList(PotreeWriterNode *node, list<PotreeWriterNode*> &list) {
+        if (node->cache.size() > 0) {
+            list.push_back(node);
+        }
+    }
 
 	void flush(){
 		root->flush();
@@ -174,7 +184,9 @@ public:
 		cloudjs.hierarchy = vector<CloudJS::Node>();
 		cloudjs.tightBoundingBox = tightAABB;
 		list<PotreeWriterNode*> stack;
+        list<PotreeWriterNode*> toBeFlushed;
 		stack.push_back(root);
+        addToFlushList(root, toBeFlushed);
 		while(!stack.empty()){
 			PotreeWriterNode *node = stack.front();
 			stack.pop_front();
@@ -185,6 +197,7 @@ public:
 			for(int i = 0; i < 8; i++){
 				if(node->children[i] != NULL){
 					stack.push_back(node->children[i]);
+                    addToFlushList(node->children[i], toBeFlushed);
 				}
 			}
 		}

--- a/PotreeConverter/include/PotreeWriterRandom.hpp
+++ b/PotreeConverter/include/PotreeWriterRandom.hpp
@@ -176,13 +176,28 @@ public:
 		tightAABB.update(position);
 
 		if(cache.size() >= 10*1000*1000){
-			flush();
+			flush(false);
 		}
 	}
+    
+    string getExtension(){
+        if(outputFormat == OutputFormat::LAS){
+            return ".las";
+        }else if(outputFormat == OutputFormat::LAZ){
+            return ".laz";
+        }else if(outputFormat == OutputFormat::BINARY){
+            return ".bin";
+        }
+        
+        return "";
+    }
 
+    void flush() {
+        flush(false);
+    }
 	
 
-	void flush(){
+	void flush(bool createEmptyFiles){
 
 		cloudjs.boundingBox = aabb;
 		cloudjs.tightBoundingBox = tightAABB;
@@ -315,7 +330,7 @@ public:
 
 			stringstream filename;
 			filename << path << "/data/" << current->name;
-			if(!fs::exists(fs::path(filename.str()))){
+			if(createEmptyFiles && !fs::exists(fs::path(filename.str() + getExtension()))){
 				//LASPointWriter *writer = new LASPointWriter(filename.str(), current->aabb, scale);
 				PointWriter *writer = createWriter(filename.str(), scale, current->aabb);
 				writer->close();
@@ -326,15 +341,16 @@ public:
 			pos++;
 		}
 
+        if (createEmptyFiles) {
 		ofstream cloudOut(path + "/cloud.js", ios::out);
 		cloudOut << cloudjs.getString();
 		cloudOut.close();
-		
+        }
 
 	}
 
 	void close(){
-		flush();
+		flush(true);
 	}
 
 	long long numPointsWritten(){

--- a/PotreeConverter/src/PotreeWriterDartThrowing.cpp
+++ b/PotreeConverter/src/PotreeWriterDartThrowing.cpp
@@ -186,10 +186,4 @@ void PotreeWriterNode::flush(){
 	}
 	
 	addCalledSinceLastFlush = false;
-
-	for(int i = 0; i < 8; i++){
-		if(children[i] != NULL){
-			children[i]->flush();
-		}
-	}
 }

--- a/PotreeConverter/src/PotreeWriterDartThrowing.cpp
+++ b/PotreeConverter/src/PotreeWriterDartThrowing.cpp
@@ -156,23 +156,8 @@ void PotreeWriterNode::flush(){
 	if(cache.size() > 0){
 		 // move data file aside to temporary directory for reading
 		string filepath = path + "/data/" + name + potreeWriter->getExtension();
-		string temppath = path +"/temp/prepend" + potreeWriter->getExtension();
-		if(fs::exists(filepath)){
-			fs::rename(fs::path(filepath), fs::path(temppath));
-		}
-		
 
-		PointWriter *writer = createWriter(path + "/data/" + name + potreeWriter->getExtension(), scale);
-		if(fs::exists(temppath)){
-			PointReader *reader = createReader(temppath);
-			while(reader->readNextPoint()){
-				writer->write(reader->getPoint());
-			}
-			reader->close();
-			delete reader;
-			fs::remove(temppath);
-		}
-
+        PointWriter *writer = createWriter(path + "/data/" + name + potreeWriter->getExtension(), scale);
 		for(int i = 0; i < cache.size(); i++){
 			writer->write(cache[i]);
 		}


### PR DESCRIPTION
With this patch, the empty datafiles are created only once, whet the Writer is closed. The continuous scan for missing empty datafiles occupied more than 96% of the conversion time on big clouds.
For the same reason, the cloud.js descriptor is created only at the end.

As drawback, the cloud is not usable until it's fully converted, but for large clouds, the conversion was endless.