### PR TITLE
BINPointWriter copies the intensity to RGB if intensity present and RGB missing.

### DIFF
--- a/PotreeConverter/include/BINPointWriter.hpp
+++ b/PotreeConverter/include/BINPointWriter.hpp
@@ -62,8 +62,14 @@ public:
 				int pos[3] = {x, y, z};
 				writer->write((const char*)pos, 3*sizeof(int));
 			}else if(attribute == PointAttribute::COLOR_PACKED){
+                if (point.r == 0 && point.g == 0 && point.b == 0 && point.intensity != 0) {
+                    unsigned char i = point.intensity >> 8;
+                    unsigned char rgba[4] = {i, i, i, 255};
+                    writer->write((const char*)rgba, 4*sizeof(unsigned char));
+                } else {
 				unsigned char rgba[4] = {point.r, point.g, point.b, 255};
 				writer->write((const char*)rgba, 4*sizeof(unsigned char));
+                }
 			}
 		}
 


### PR DESCRIPTION
While we cannot store the intensity in BIN files, the BINPointReader copies the intensity value in the RGB fields, if intensity is not zero and RGB are zeroes.