### PR TITLE
Patched windows path length limit

### DIFF
--- a/PotreeConverter/src/PotreeWriter.cpp
+++ b/PotreeConverter/src/PotreeWriter.cpp
@@ -51,9 +51,9 @@ string PotreeWriterNode::hierarchyPath(){
 		path = "";
 	}else{
 		path = "";
-		for(int i = 0; i < numParts; i++){
-			path += "r" + indices.substr(0, i*hierachyStepSize) + "/";
-		}
+		for(int i = 0; i < indices.length(); i++){
+                        path += indices.substr(i,1)+ "/";
+                }
 	}
 
 	return path;


### PR DESCRIPTION
In highly nested trees (20+ levels of detail) it is possible to hit the windows path-length limit (255/6 chars) [1]
[1] https://stackoverflow.com/questions/1880321/why-does-the-260-character-path-length-limit-exist-in-windows

Before:
r/r0/r01/r010/r0101/r01012/r010123/r0101232....
After:
r/0/1/0/1/2/3/2/...