### PR TITLE
neighbours vector uses reserve(26) and isDistant() uses squared values.

### DIFF
--- a/PotreeConverter/include/SparseGrid.h
+++ b/PotreeConverter/include/SparseGrid.h
@@ -24,7 +24,6 @@ public:
 	int width;
 	int height;
 	int depth;
-	float spacing;
 	AABB aabb;
 	float squaredSpacing;
 	int numAccepted;
@@ -34,7 +33,7 @@ public:
 	SparseGrid(AABB aabb, float minGap);
 
 	SparseGrid(const SparseGrid &other)
-		: width(other.width), height(other.height), depth(other.depth), spacing(other.spacing), aabb(other.aabb), squaredSpacing(other.squaredSpacing), numAccepted(other.numAccepted)
+		: width(other.width), height(other.height), depth(other.depth), aabb(other.aabb), squaredSpacing(other.squaredSpacing), numAccepted(other.numAccepted)
 	{
 		count++;
 	}
@@ -44,10 +43,6 @@ public:
 	vector<GridCell*> targetArea(int x, int y, int z);
 
 	bool isDistant(const Vector3<double> &p, int i, int j, int k);
-
-	float minGap(const Vector3<double> &p, int i, int j, int k);
-
-	float minGap(const Vector3<double> &p);
 
 	bool add(Vector3<double> &p);
 

--- a/PotreeConverter/src/GridCell.cpp
+++ b/PotreeConverter/src/GridCell.cpp
@@ -17,6 +17,7 @@ GridCell::GridCell(){
 
 GridCell::GridCell(SparseGrid *grid, GridIndex &index){
 	this->grid = grid;
+    neighbours.reserve(26);
 
 	for(int i = max(index.i -1, 0); i <= min(grid->width-1, index.i + 1); i++){
 		for(int j = max(index.j -1, 0); j <= min(grid->height-1, index.j + 1); j++){

--- a/PotreeConverter/src/SparseGrid.cpp
+++ b/PotreeConverter/src/SparseGrid.cpp
@@ -15,7 +15,7 @@ SparseGrid::SparseGrid(AABB aabb, float spacing){
 	this->width = (int)(aabb.size.x / spacing);
 	this->height = (int)(aabb.size.y / spacing);
 	this->depth = (int)(aabb.size.z / spacing);
-	this->spacing = spacing;
+	this->squaredSpacing = spacing * spacing;
 	numAccepted = 0;
 }
 
@@ -51,48 +51,18 @@ vector<GridCell*> SparseGrid::targetArea(int x, int y, int z){
 
 bool SparseGrid::isDistant(const Vector3<double> &p, int i, int j, int k){
 	GridCell *cell = this->operator[](GridIndex(i,j,k));
-	if(cell->minGap(p) < spacing){
+	if(cell->squaredMinGap(p) < squaredSpacing){
 		return false;
 	}
 	for(int a = 0; a < cell->neighbours.size(); a++){
 		GridCell *neighbour = cell->neighbours[a];
-		float gap = neighbour->minGap(p);
-		if(gap < spacing){
+		float gap = neighbour->squaredMinGap(p);
+		if(gap < squaredSpacing){
 			return false;
 		}
 	}
 
 	return true;
-}
-
-float SparseGrid::minGap(const Vector3<double> &p){
-	int nx = (int)(width*(p.x - aabb.min.x) / aabb.size.x);
-	int ny = (int)(height*(p.y - aabb.min.y) / aabb.size.y);
-	int nz = (int)(depth*(p.z - aabb.min.z) / aabb.size.z);
-
-	int i = min(nx, width-1);
-	int j = min(ny, height-1);
-	int k = min(nz, depth-1);
-
-	GridIndex index(i,j,k);
-	if(find(index) == end()){
-		this->operator[](index) = new GridCell(this, index);
-	}
-
-	return minGap(p, i, j, k);
-}
-
-float SparseGrid::minGap(const Vector3<double> &p, int i, int j, int k){
-	GridCell *cell = this->operator[](GridIndex(i,j,k));
-	float minGap = MAX_FLOAT;
-
-	minGap = min(cell->minGap(p), minGap);
-	for(int a = 0; a < cell->neighbours.size(); a++){
-		GridCell *neighbour = cell->neighbours[a];
-		minGap = min(minGap, neighbour->minGap(p));
-	}
-
-	return minGap;
 }
 
 bool SparseGrid::add(Vector3<double> &p){


### PR DESCRIPTION
A little optimization in SparseGrid::isDistant() (that does not use squared roots) and GridCell:GridCell that pre-allocates the neighbours vector.