### PR TITLE
Simplification in PotreeConvcerter::PotreeConverter() signature.

### DIFF
--- a/PotreeConverter/include/PotreeConverter.h
+++ b/PotreeConverter/include/PotreeConverter.h
@@ -36,6 +36,20 @@ struct ProcessResult{
 	}
 };
 
+struct Options {
+    vector<string> sources;
+    string workDir;
+    float spacing;
+    int diagonalFraction;
+    int maxDepth;
+    string format;
+    vector<double> colorRange;
+    vector<double> intensityRange;
+    double scale;
+    OutputFormat outFormat;
+    vector<string> outputAttributes;
+};
+
 class PotreeConverter{
 
 private:
@@ -57,18 +71,7 @@ private:
 
 public:
 
-	PotreeConverter(
-		vector<string> fData, 
-		string workDir, 
-		float spacing, 
-		int diagonalFraction, 
-		int maxDepth, 
-		string format, 
-		vector<double> colorRange, 
-		vector<double> intensityRange, 
-		double scale, 
-		OutputFormat outFormat,
-		vector<string> outputAttributes);
+	PotreeConverter(Options options);
 
 	void convert();
 

--- a/PotreeConverter/src/PotreeConverter.cpp
+++ b/PotreeConverter/src/PotreeConverter.cpp
@@ -72,23 +72,12 @@ PointReader *PotreeConverter::createPointReader(string path){
 	return reader;
 }
 
-PotreeConverter::PotreeConverter(
-	vector<string> sources, 
-	string workDir, 
-	float spacing, 
-	int diagonalFraction,
-	int maxDepth, 
-	string format, 
-	vector<double> colorRange, 
-	vector<double> intensityRange, 
-	double scale, 
-	OutputFormat outFormat,
-	vector<string> outputAttributes){
+PotreeConverter::PotreeConverter(Options options){
 
 	// if sources contains directories, use files inside the directory instead
 	vector<string> sourceFiles;
-	for(int i = 0; i < sources.size(); i++){
-		string source = sources[i];
+	for(int i = 0; i < options.sources.size(); i++){
+		string source = options.sources[i];
 		path pSource(source);
 		if(boost::filesystem::is_directory(pSource)){
 			boost::filesystem::directory_iterator it(pSource);
@@ -113,16 +102,16 @@ PotreeConverter::PotreeConverter(
 	
 
 	this->sources = sourceFiles;
-	this->workDir = workDir;
-	this->spacing = spacing;
-	this->maxDepth = maxDepth;
-	this->format = format;
-	this->colorRange = colorRange;
-	this->intensityRange = intensityRange;
-	this->scale = scale;
-	this->outputFormat = outFormat;
-	this->outputAttributes = outputAttributes;
-	this->diagonalFraction = diagonalFraction;
+	this->workDir = options.workDir;
+	this->spacing = options.spacing;
+	this->maxDepth = options.maxDepth;
+	this->format = options.format;
+	this->colorRange = options.colorRange;
+	this->intensityRange = options.intensityRange;
+	this->scale = options.scale;
+	this->outputFormat = options.outFormat;
+	this->outputAttributes = options.outputAttributes;
+	this->diagonalFraction = options.diagonalFraction;
 
 	boost::filesystem::path dataDir(workDir + "/data");
 	boost::filesystem::path tempDir(workDir + "/temp");

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -240,10 +240,12 @@ int main(int argc, char **argv){
         outdir,
         spacing,
         diagonalFraction,
-        levels, format,
+        levels,
+        format,
         colorRange,
         intensityRange,
-        scale, outFormat,
+        scale,
+        outFormat,
         outputAttributes
     };
     

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -235,8 +235,20 @@ int main(int argc, char **argv){
 		}
 	}
 	
+    Options options = {
+        source,
+        outdir,
+        spacing,
+        diagonalFraction,
+        levels, format,
+        colorRange,
+        intensityRange,
+        scale, outFormat,
+        outputAttributes
+    };
+    
 	try{
-		PotreeConverter pc(source, outdir, spacing, diagonalFraction, levels, format, colorRange, intensityRange, scale, outFormat, outputAttributes);
+		PotreeConverter pc(options);
 		pc.convert();
 	}catch(exception &e){
 		cout << "ERROR: " << e.what() << endl;


### PR DESCRIPTION
Hi. This patch simplifies the signature of the PotreeConverter constructor. As parameters grow, so grows the risk of conflicts.