### PR TITLE
Fix 'use of deleted function' compiler errors

### DIFF
--- a/PotreeConverter/include/PTXPointReader.h
+++ b/PotreeConverter/include/PTXPointReader.h
@@ -28,7 +28,7 @@ private:
         return p;
     }
 
-    fstream stream;
+    fstream *stream;
     string path;
     vector<string> files;
     vector<string>::iterator currentFile;
@@ -37,7 +37,7 @@ private:
     /**
     * Returns false if there is neo next chunk.
     */
-    bool loadChunk(fstream &stream, long currentChunk, double tr[16]);
+    bool loadChunk(fstream *stream, long currentChunk, double tr[16]);
 
     void scanForAABB();
 
@@ -76,7 +76,7 @@ public:
     }
 
     inline void close() {
-        stream.close();
+        stream->close();
     }
 };
 

--- a/PotreeConverter/include/stuff.h
+++ b/PotreeConverter/include/stuff.h
@@ -2,6 +2,14 @@
 #ifndef STUFF_H
 #define STUFF_H
 
+// BOOST_VERSION % 100 is the patch level
+// BOOST_VERSION / 100 % 1000 is the minor version
+// BOOST_VERSION / 100000 is the major version/
+
+#if (BOOST_VERSION < 105700)
+#define BOOST_NO_CXX11_SCOPED_ENUMS
+#endif
+
 #include <vector>
 #include <map>
 #include <iostream>

--- a/PotreeConverter/src/PTXPointReader.cpp
+++ b/PotreeConverter/src/PTXPointReader.cpp
@@ -31,19 +31,19 @@ inline void split(vector<double> &v, char (&str)[512]) {
     }
 }
 
-inline void getlined(fstream &stream, vector<double> &result) {
+inline void getlined(fstream *stream, vector<double> &result) {
     char str[512];
     result.clear();
-    stream.getline(str, 512);
+    stream->getline(str, 512);
     split(result, str);
 }
 
-inline void skipline(fstream &stream) {
+inline void skipline(fstream *stream) {
     string str;
-    getline(stream, str);
+    getline(*stream, str);
 }
 
-bool assertd(fstream &stream, int i) {
+bool assertd(fstream *stream, int i) {
     vector<double> tokens;
     getlined(stream, tokens);
     bool result = i == tokens.size();
@@ -80,7 +80,7 @@ PTXPointReader::PTXPointReader(string path) {
 
     // open first file
     this->currentFile = files.begin();
-    this->stream = fstream(*(this->currentFile), ios::in);
+    this->stream = new fstream(*(this->currentFile), ios::in);
     this->currentChunk = 0;
     skipline(this->stream);
     loadChunk(this->stream, this->currentChunk, this->tr);
@@ -96,7 +96,7 @@ void PTXPointReader::scanForAABB() {
     double tr[16];
     vector<double> split;
     for (int i = 0; i < files.size(); i++) {
-        fstream stream = fstream(files[i], ios::in);
+        fstream *stream=new fstream(files[i], ios::in);
         currentChunk = 0;
         getlined(stream, split);
         while (!pleaseStop) {
@@ -135,13 +135,13 @@ void PTXPointReader::scanForAABB() {
                     break;
                 }
             }
-            if (stream.eof()) {
+            if (stream->eof()) {
                 pleaseStop = true;
                 break;
             }
             currentChunk++;
         }
-        stream.close();
+        stream->close();
     }
 
     counts[path] = count;
@@ -149,7 +149,7 @@ void PTXPointReader::scanForAABB() {
     PTXPointReader::aabbs[path] = lAABB;
 }
 
-bool PTXPointReader::loadChunk(fstream &stream, long currentChunk, double tr[16]) {
+bool PTXPointReader::loadChunk(fstream *stream, long currentChunk, double tr[16]) {
     vector<double> split;
 
     // The first 5 lines should have respectively 1, 3, 3, 3, 3 numbers each.
@@ -208,12 +208,12 @@ bool PTXPointReader::readNextPoint() {
 }
 
 bool PTXPointReader::doReadNextPoint() {
-    if (this->stream.eof()) {
-        this->stream.close();
+    if (this->stream->eof()) {
+        this->stream->close();
         this->currentFile++;
 
         if (this->currentFile != files.end()) {
-            this->stream = fstream(*(this->currentFile), ios::in);
+            this->stream = new fstream(*(this->currentFile), ios::in);
             this->currentChunk = 0;
             skipline(stream);
             loadChunk(stream, currentChunk, tr);


### PR DESCRIPTION
Hello,

I had several " error: use of deleted function" compilation errors in PTXPointReader.cpp and the patch from anttiviljami did not solve the problem.

Replacing the input stream object reference with a pointer solved the problem.

Linking with libboost 1.55 (<1.57) required the BOOST_NO_CXX11_SCOPED_ENUMS patch in stuff.h as proposed by anttiviljami (thanks !)
