### PR TITLE
Use BOOST_NO_CXX11_SCOPED_ENUMS in older versions of boost

### DIFF
--- a/PotreeConverter/include/stuff.h
+++ b/PotreeConverter/include/stuff.h
@@ -2,6 +2,14 @@
 #ifndef STUFF_H
 #define STUFF_H
 
+// BOOST_VERSION % 100 is the patch level
+// BOOST_VERSION / 100 % 1000 is the minor version
+// BOOST_VERSION / 100000 is the major version/
+
+#if (BOOST_VERSION < 105700)
+#define BOOST_NO_CXX11_SCOPED_ENUMS
+#endif
+
 #include <vector>
 #include <map>
 #include <iostream>


### PR DESCRIPTION
This patch did not work with boost 1.56 on windows => Boost 1.58 is a minimum requirement on windows now.

Thanks for the PR.