### PR TITLE
Fix for compiling potree on Ubuntu 14

### DIFF
--- a/PotreeConverter/CMakeLists.txt
+++ b/PotreeConverter/CMakeLists.txt
@@ -4,6 +4,9 @@ file(GLOB files src/*.cpp include/*.h include/*.hpp )
 
 include_directories(include ${LIBLAS_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
 
+add_definitions(-D BOOST_NO_SCOPED_ENUMS)
+add_definitions(-D BOOST_NO_CXX11_SCOPED_ENUMS)
+
 add_executable(PotreeConverter ${files})
 target_link_libraries(PotreeConverter ${LIBLAS_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_REGEX_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 

--- a/PotreeConverter/src/PTXPointReader.cpp
+++ b/PotreeConverter/src/PTXPointReader.cpp
@@ -80,7 +80,7 @@ PTXPointReader::PTXPointReader(string path) {
 
     // open first file
     this->currentFile = files.begin();
-    this->stream = fstream(*(this->currentFile), ios::in);
+    this->stream.open(*(this->currentFile), ios::in);
     this->currentChunk = 0;
     skipline(this->stream);
     loadChunk(this->stream, this->currentChunk, this->tr);
@@ -96,7 +96,7 @@ void PTXPointReader::scanForAABB() {
     double tr[16];
     vector<double> split;
     for (int i = 0; i < files.size(); i++) {
-        fstream stream = fstream(files[i], ios::in);
+        fstream stream(files[i], ios::in);
         currentChunk = 0;
         getlined(stream, split);
         while (!pleaseStop) {
@@ -213,7 +213,7 @@ bool PTXPointReader::doReadNextPoint() {
         this->currentFile++;
 
         if (this->currentFile != files.end()) {
-            this->stream = fstream(*(this->currentFile), ios::in);
+            this->stream.open(*(this->currentFile), ios::in);
             this->currentChunk = 0;
             skipline(stream);
             loadChunk(stream, currentChunk, tr);


### PR DESCRIPTION
PotreeConverter doesn't compile on Ubuntu (and probably any other gcc) because there are a couple of streams getting assigned, which is forbidden by the standard and in C++11 enforced with deleted assignment:

> PTXPointReader.cpp:83:18: error: use of deleted function 'std::basic_fstream<char>& std::basic_fstream<char>::operator=(const std::basic_fstream<char>&)'
     this->stream = fstream(*(this->currentFile), ios::in);

So I basically fixed all the assignments.

The other issue that pops up is a linker error due to some hickup in Boost Filesystem when being compile with -std=c++11 (see [this link](https://www.robertnitsch.de/notes/cpp/cpp11_boost_filesystem_undefined_reference_copy_file)):

> In function `boost::filesystem::copy_file(boost::filesystem::path const&, boost::filesystem::path const&, boost::filesystem::copy_option)':
stuff.cpp:(.text._ZN5boost10filesystem9copy_fileERKNS0_4pathES3_NS0_11copy_optionE[_ZN5boost10filesystem9copy_fileERKNS0_4pathES3_NS0_11copy_optionE]+0x27): undefined reference to `boost::filesystem::detail::copy_file(boost::filesystem::path const&, boost::filesystem::path const&, boost::filesystem::copy_option, boost::system::error_code*)'

I fixed this with the two definitions in the CMakeLists.txt. The first one is deprecated for versions above Boost 1.51, so there is some room for improvement there ;-)