### PR TITLE
User able to indicate AABB to be used for octree generation

### DIFF
--- a/PotreeConverter/include/PotreeConverter.h
+++ b/PotreeConverter/include/PotreeConverter.h
@@ -52,6 +52,7 @@ private:
 	vector<double> intensityRange;
 	double scale;
 	int diagonalFraction;
+	vector<double> aabbValues;
 
 	PointReader *createPointReader(string source, PointAttributes pointAttributes);
 
@@ -68,8 +69,9 @@ public:
 		vector<double> intensityRange, 
 		double scale, 
 		OutputFormat outFormat,
-		vector<string> outputAttributes);
-
+		vector<string> outputAttributes,
+		vector<double> aabbValues);
+		
 	void convert();
 
 };

--- a/PotreeConverter/src/PotreeConverter.cpp
+++ b/PotreeConverter/src/PotreeConverter.cpp
@@ -87,8 +87,9 @@ PotreeConverter::PotreeConverter(
 	vector<double> intensityRange, 
 	double scale, 
 	OutputFormat outFormat,
-	vector<string> outputAttributes){
-
+	vector<string> outputAttributes),
+	vector<double> aabbValues){
+	
 	// if sources contains directories, use files inside the directory instead
 	vector<string> sourceFiles;
 	for(int i = 0; i < sources.size(); i++){
@@ -127,6 +128,7 @@ PotreeConverter::PotreeConverter(
 	this->outputFormat = outFormat;
 	this->outputAttributes = outputAttributes;
 	this->diagonalFraction = diagonalFraction;
+	this->aabbValues = aabbValues;
 
 	boost::filesystem::path dataDir(workDir + "/data");
 	boost::filesystem::path tempDir(workDir + "/temp");
@@ -213,16 +215,23 @@ void PotreeConverter::convert(){
 
 	// calculate AABB and total number of points
 	AABB aabb;
+	// if aabbValues is given by the user we set the the variable aabb with them
+	if(aabbValues.size() == 6){
+		Vector3<double> userMin(aabbValues[0],aabbValues[1],aabbValues[2]);
+		Vector3<double> userMax(aabbValues[3],aabbValues[4],aabbValues[5]);
+		aabb = AABB(userMin, userMax);
+	}
+
 	long long numPoints = 0;
 	for(string source : sources){
 
 		PointReader *reader = createPointReader(source, pointAttributes);
-		AABB lAABB = reader->getAABB();
-		 
-
-		aabb.update(lAABB.min);
-		aabb.update(lAABB.max);
-
+		// we update the AABB only if it was not provided by the user
+		if (aabbValues.size() == 0){	
+			AABB lAABB = reader->getAABB();
+			aabb.update(lAABB.min);
+			aabb.update(lAABB.max);
+		}
 		numPoints += reader->numPoints();
 
 		reader->close();

--- a/PotreeConverter/src/PotreeConverter.cpp
+++ b/PotreeConverter/src/PotreeConverter.cpp
@@ -87,7 +87,7 @@ PotreeConverter::PotreeConverter(
 	vector<double> intensityRange, 
 	double scale, 
 	OutputFormat outFormat,
-	vector<string> outputAttributes),
+	vector<string> outputAttributes,
 	vector<double> aabbValues){
 	
 	// if sources contains directories, use files inside the directory instead

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv){
 	vector<double> intensityRange;
 	vector<string> outputAttributes;
 	bool generatePage;
-	string aabbValuesString
+	string aabbValuesString;
 	vector<double> aabbValues;
 
 	cout.imbue(std::locale(""));
@@ -135,7 +135,7 @@ int main(int argc, char **argv){
 
 
 		if(vm.count("aabb")){
-			char sep = ','; 
+			char sep = ' '; 
 			for(size_t p=0, q=0; p!=aabbValuesString.npos; p=q)
     			aabbValues.push_back(atof(aabbValuesString.substr(p+(p!=0), (q=aabbValuesString.find(sep, p+1))-p-(p!=0)).c_str())); 
 

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -66,7 +66,8 @@ int main(int argc, char **argv){
 	vector<double> intensityRange;
 	vector<string> outputAttributes;
 	bool generatePage;
-
+	string aabbValuesString
+	vector<double> aabbValues;
 
 	cout.imbue(std::locale(""));
 
@@ -86,6 +87,7 @@ int main(int argc, char **argv){
 			("output-format", po::value<string>(&outFormatString), "Output format can be BINARY, LAS or LAZ. Default is BINARY")
 			("output-attributes,a", po::value<std::vector<std::string> >()->multitoken(), "can be any combination of RGB, INTENSITY and CLASSIFICATION. Default is RGB.")
 			("scale", po::value<double>(&scale), "Scale of the X, Y, Z coordinate in LAS and LAZ files.")
+			("aabb", po::value<string>(&aabbValuesString), "Bounding cube as \"minX minY minZ maxX maxY maxZ\". If not provided it is automatically computed")
 			("source", po::value<std::vector<std::string> >(), "Source file. Can be LAS, LAZ, PTX or PLY");
 		po::positional_options_description p; 
 		p.add("source", -1); 
@@ -129,6 +131,18 @@ int main(int argc, char **argv){
 			outputAttributes = vm["output-attributes"].as< vector<string> >();
 		}else{
 			outputAttributes.push_back("RGB");
+		}
+
+
+		if(vm.count("aabb")){
+			char sep = ','; 
+			for(size_t p=0, q=0; p!=aabbValuesString.npos; p=q)
+    			aabbValues.push_back(atof(aabbValuesString.substr(p+(p!=0), (q=aabbValuesString.find(sep, p+1))-p-(p!=0)).c_str())); 
+
+			if(aabbValues.size() != 6){
+				cerr << "AABB requires 6 arguments" << endl;
+				return 1;
+			}
 		}
 
 		// set default parameters 
@@ -238,7 +252,7 @@ int main(int argc, char **argv){
 	}
 	
 	try{
-		PotreeConverter pc(source, outdir, spacing, diagonalFraction, levels, format, colorRange, intensityRange, scale, outFormat, outputAttributes);
+		PotreeConverter pc(source, outdir, spacing, diagonalFraction, levels, format, colorRange, intensityRange, scale, outFormat, outputAttributes, aabbValues);
 		pc.convert();
 	}catch(exception &e){
 		cout << "ERROR: " << e.what() << endl;


### PR DESCRIPTION
The user is now able to indicate a AABB to be used for the octree generation. If not provided it will be automatically computed (like it was done before)
Using a fixed AABB together with using fixed spacing and number of levels allows to combine octrees into a single one. See [Massive-PotreeConverter] (https://github.com/NLeSC/Massive-PotreeConverter)

Usage example:

PotreeConverter -o /pak1/ltdata/test_potree_converter -l 8 --output-format LAZ --source /pak2/usrdata/ahn2/benchmarks/000020m/ahn_bench000020.las -s 18 --aabb "13420.00 306740.00 -30.00 278490.00 615440.00 400.00"