### PR TITLE
Efficiency: Improved for loops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(Boost COMPONENTS system thread filesystem program_options regex REQ
 
 if(UNIX)
 #  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-compare -std=c++0x -pthread -lstdc++ -lm")
 #  endif()
 endif()
 

--- a/PotreeConverter/include/LASPointReader.h
+++ b/PotreeConverter/include/LASPointReader.h
@@ -51,8 +51,7 @@ public:
 		hasTransform = false;
 
 //      cout << "There are " << vlrs.size() << " VLRs." << endl;
-        for (int i = 0; i < vlrs.size(); ++i) {
-            liblas::VariableRecord vlr = vlrs[i];
+	for (const auto &vlr : vlrs) {
             if (vlr.GetRecordId() == 2001) {
                 const uint8_t *data = vlr.GetData().data();
                 for (int k = 0; k < 16; ++k) {

--- a/PotreeConverter/include/PlyPointReader.h
+++ b/PotreeConverter/include/PlyPointReader.h
@@ -221,8 +221,7 @@ public:
 			stream.read(buffer, pointByteSize);
 
 			int offset = 0;
-			for(int i = 0; i < vertexElement.properties.size(); i++){
-				PlyProperty prop = vertexElement.properties[i];
+			for(const auto &prop : vertexElement.properties){
 				if(prop.name == "x" && prop.type.name == plyPropertyTypes["float"].name){
 					memcpy(&dummy, (buffer+offset), prop.type.size);
 					x=dummy;

--- a/PotreeConverter/include/PotreeWriter.h
+++ b/PotreeConverter/include/PotreeWriter.h
@@ -253,8 +253,7 @@ public:
 				ofstream fout;
 				fout.open(dest, ios::out | ios::binary);
 				vector<PotreeWriterNode*> hierarchy = node->getHierarchy(hierarchyStepSize + 1);
-				for(int i = 0; i <  hierarchy.size(); i++){
-					PotreeWriterNode *descendant = hierarchy[i];
+				for(const auto &descendant : hierarchy){
 					if(descendant->level == node->level + hierarchyStepSize && (node->level + hierarchyStepSize) < maxLevel ){
 						stack.push_back(descendant);
 					}

--- a/PotreeConverter/include/Vector3.h
+++ b/PotreeConverter/include/Vector3.h
@@ -59,11 +59,11 @@ public:
 		return x*x + y*y + z*z;
 	}
 
-	T distanceTo(Vector3<T> p){
+	T distanceTo(Vector3<T> p) const{
 		return ((*this) - p).length();
 	}
 
-	T squaredDistanceTo(const Vector3<T> &p){
+	T squaredDistanceTo(const Vector3<T> &p) const{
 		return ((*this) - p).squaredLength();
 	}
 

--- a/PotreeConverter/src/GridCell.cpp
+++ b/PotreeConverter/src/GridCell.cpp
@@ -41,8 +41,7 @@ GridCell::GridCell(SparseGrid *grid, GridIndex &index){
 float GridCell::minGap(const Vector3<double> &p){
 	float minGap = MAX_FLOAT;
 
-	for(int i = 0; i < points.size(); i++){
-		Vector3<double> point = points[i];
+	for (const auto &point :  points){
 		minGap = min(minGap, (float)point.distanceTo(p));
 	}
 
@@ -52,8 +51,7 @@ float GridCell::minGap(const Vector3<double> &p){
 float GridCell::squaredMinGap(const Vector3<double> &p){
 	float minGap = MAX_FLOAT;
 
-	for(int i = 0; i < points.size(); i++){
-		Vector3<double> point = points[i];
+	for (const auto &point :  points){
 		minGap = min(minGap, (float)point.squaredDistanceTo(p));
 	}
 
@@ -62,10 +60,8 @@ float GridCell::squaredMinGap(const Vector3<double> &p){
 
 float GridCell::minGapAtArea(const Vector3<double> &p){
 	float areaGap = MAX_FLOAT;
-	for(int a = 0; a < neighbours.size(); a++){
-		GridCell *neighbour = neighbours[a];
-		float gap = neighbour->minGap(p);
-		areaGap = min(gap, areaGap);
+	for (const auto &neighbour :  neighbours){
+		areaGap = min(neighbour->minGap(p), areaGap);
 	}
 
 	return areaGap;

--- a/PotreeConverter/src/LASPointReader.cpp
+++ b/PotreeConverter/src/LASPointReader.cpp
@@ -57,9 +57,7 @@ LASPointReader::LASPointReader(string path){
 	
 
 	// read bounding box
-	for(int i = 0; i < files.size(); i++){
-		string file = files[i];
-
+	for (const auto &file : files) {
 		LIBLASReader aabbReader(file);
 		AABB lAABB = aabbReader.getAABB();
 		

--- a/PotreeConverter/src/PTXPointReader.cpp
+++ b/PotreeConverter/src/PTXPointReader.cpp
@@ -43,11 +43,10 @@ inline void skipline(fstream &stream) {
     getline(stream, str);
 }
 
-bool assertd(fstream &stream, int i) {
+bool assertd(fstream &stream, size_t i) {
     vector<double> tokens;
     getlined(stream, tokens);
-    bool result = i == tokens.size();
-    return result;
+    return  i == tokens.size();
 }
 
 /**
@@ -95,8 +94,8 @@ void PTXPointReader::scanForAABB() {
     long count = 0;
     double tr[16];
     vector<double> split;
-    for (int i = 0; i < files.size(); i++) {
-        fstream stream(files[i], ios::in);
+    for (const auto &file : files) {
+        fstream stream(file, ios::in);
         currentChunk = 0;
         getlined(stream, split);
         while (!pleaseStop) {

--- a/PotreeConverter/src/PotreeConverter.cpp
+++ b/PotreeConverter/src/PotreeConverter.cpp
@@ -92,8 +92,7 @@ PotreeConverter::PotreeConverter(
 	
 	// if sources contains directories, use files inside the directory instead
 	vector<string> sourceFiles;
-	for(int i = 0; i < sources.size(); i++){
-		string source = sources[i];
+	for (const auto &source : sources) {
 		path pSource(source);
 		if(boost::filesystem::is_directory(pSource)){
 			boost::filesystem::directory_iterator it(pSource);
@@ -150,9 +149,7 @@ void PotreeConverter::convert(){
 	PointAttributes pointAttributes;
 	pointAttributes.add(PointAttribute::POSITION_CARTESIAN);
 
-	for(int i = 0; i < outputAttributes.size(); i++){
-		string attribute = outputAttributes[i];
-
+	for(const auto &attribute : outputAttributes){
 		if(attribute == "RGB"){
 			pointAttributes.add(PointAttribute::COLOR_PACKED);
 		}else if(attribute == "INTENSITY"){
@@ -273,8 +270,7 @@ void PotreeConverter::convert(){
 	//PotreeWriterLBL writer(this->workDir, aabb, spacing, maxDepth, outputFormat);
 
 	pointsProcessed = 0;
-	for(int i = 0; i < sources.size(); i++){
-		string source = sources[i];
+	for (const auto &source : sources) {
 		cout << "reading " << source << endl;
 
 		PointReader *reader = createPointReader(source, pointAttributes);

--- a/PotreeConverter/src/PotreeWriter.cpp
+++ b/PotreeConverter/src/PotreeWriter.cpp
@@ -199,8 +199,8 @@ void PotreeWriterNode::flush(){
 			fs::remove(temppath);
 		}
 
-		for(int i = 0; i < cache.size(); i++){
-			writer->write(cache[i]);
+		for(const auto &e_c : cache){
+			writer->write(e_c);
 		}
 		writer->close();
 		delete writer;

--- a/PotreeConverter/src/SparseGrid.cpp
+++ b/PotreeConverter/src/SparseGrid.cpp
@@ -34,8 +34,7 @@ bool SparseGrid::isDistant(const Vector3<double> &p, GridCell *cell){
 		return false;
 	}
 
-	for(int a = 0; a < cell->neighbours.size(); a++){
-		GridCell *neighbour = cell->neighbours[a];
+	for(const auto &neighbour : cell->neighbours) {
 		if(!neighbour->isDistant(p, squaredSpacing)){
 			return false;
 		}

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -169,8 +169,10 @@ int main(int argc, char **argv){
 		}
 
 		cout << "== params ==" << endl;
-		for(int i = 0; i < source.size(); i++){
+		int i = 0;
+		for(const auto &s : source) {
 			cout << "source[" << i << "]:         \t" << source[i] << endl;
+			++i;
 		}
 		cout << "outdir:            \t" << outdir << endl;
 		cout << "spacing:           \t" << spacing << endl;


### PR DESCRIPTION
Instaed of this:
```
        for(int a = 0; a < cell->neighbours.size(); a++){    
                GridCell *neighbour = cell->neighbours[a];
                if(!neighbour->isDistant(p, squaredSpacing)){
                        return false;
                }
        }
```
Use Range loops
```
        for(auto neighbour : cell->neighbours) {
                if(!neighbour->isDistant(p, squaredSpacing)){
                        return false;
                }
        }
```
A comparison between loops:
http://stackoverflow.com/questions/14373934/iterator-loop-vs-index-loop
The ones I changed don't need the current index.
I left this changes in the CMakelist:
```
-Wsign-compare -std=c++0x -pthread -lstdc++ -lm
```
with `-Wsign-compare `  I detected the for loops basically because in the condition there are comparison between signed and unsigned int. 
http://stackoverflow.com/questions/5416414/signed-unsigned-comparisons
