### PR TITLE
Update to support negative intensity

### DIFF
--- a/PotreeConverter/include/XYZPointReader.hpp
+++ b/PotreeConverter/include/XYZPointReader.hpp
@@ -63,7 +63,7 @@ public:
 
 		if(intensityRange.size() == 2){
 			intensityOffset = (float)intensityRange[0];
-			intensityScale = (float)intensityRange[1];
+			intensityScale = (float)intensityRange[1]-(float)intensityRange[0];
 		}else if(intensityRange.size() == 1){
 			intensityOffset = 0.0f;
 			intensityScale = (float)intensityRange[0];


### PR DESCRIPTION
Changed the IntensityScale to correctly account for negative values. The IntensityScale used on line 196 is being pulled directly from the intensity range when it should be **Maximum - Minimum** value. This would result in the upper intensity values being larger then an unsigned short and being truncated.
