### PR TITLE
Improve OS X Build Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Builds a potree octree from las, laz, binary ply, xyz or ptx files.
 
 
 lastools (from fork with cmake)
+
 ```
 cd ~/dev/workspaces/lastools
 git clone https://github.com/m-schuetz/LAStools.git master
@@ -38,8 +39,24 @@ cd master
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DLASZIP_INCLUDE_DIRS=~/dev/workspaces/lastools/master/LASzip/dll -DLASZIP_LIBRARY=~/dev/workspaces/lastools/master/LASzip/build/src/liblaszip.so ..
+make
 
 # copy ./PotreeConverter/resources/page_template to your binary working directory.
+
+```
+
+### OS X
+
+Same as the linux instructions above, except:
+
+1. Give cmake absolute paths to the LASzip tools you just built. (Otherwise make might not be able to find them)
+2. LASZip library will be called `liblaszip.dylib`, not `liblaszip.so `
+
+```
+...
+
+cmake -DCMAKE_BUILD_TYPE=Release -DLASZIP_INCLUDE_DIRS=[ABSOLUTE_PATH_TO_LASTOOLS]/master/LASzip/dll -DLASZIP_LIBRARY=[ABSOLUTE_PATH_TO_LASTOOLS]/master/LASzip/build/src/liblaszip.dylib ..
+make
 
 ```
 


### PR DESCRIPTION
In my experience this was the only way to get PotreeConverter to build on OS X (10.11).

Giving make the ~/ relative path to the LASZip dependencies caused errors like `~/dev/workspaces/lastools/master/LASzip/build/src/liblaszip.dylib is not a file or directory` on the final make step.

Also: The PotreeConverter instructions were missing the last `make` command.

Also: OS X seems to create a file called `liblaszip.dylib` not `liblaszip.so`
