### PR TITLE
Use bounding-box min as LAS offset value

### DIFF
--- a/PotreeConverter/include/LASPointWriter.hpp
+++ b/PotreeConverter/include/LASPointWriter.hpp
@@ -51,6 +51,9 @@ public:
 		header.max_x = aabb.max.x;
 		header.max_y = aabb.max.y;
 		header.max_z = aabb.max.z;
+		header.x_offset = aabb.min.x;
+		header.y_offset = aabb.min.y;
+		header.z_offset = aabb.min.z;
 		header.x_scale_factor = scale;
 		header.y_scale_factor = scale;
 		header.z_scale_factor = scale;


### PR DESCRIPTION
See issue #170 

LASzip transforms coordinates like this:

``` c
    point->X = I32_QUANTIZE((coordinates[0]-header->x_offset)/header->x_scale_factor);
    point->Y = I32_QUANTIZE((coordinates[1]-header->y_offset)/header->y_scale_factor);
    point->Z = I32_QUANTIZE((coordinates[2]-header->z_offset)/header->z_scale_factor);
```

PotreeConverter picks a `scale` value based exclusively on bounding box size (see https://github.com/potree/PotreeConverter/blob/master/PotreeConverter/src/PotreeWriter.cpp#L405)

Problems arise when you have a small box (=> small `scale`) but with big coordinates because LASzip will fail to compute `point->X|Y|Z` values.

This commit fixes the issue by settings a arbitrary offset (min bbox).

_Note: this has been tested on very few models_

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/potree/potreeconverter/205)

<!-- Reviewable:end -->
