### PR TITLE
Bug: hierarchy files without data for some nodes

### DIFF
--- a/PotreeConverter/include/PotreeWriter.h
+++ b/PotreeConverter/include/PotreeWriter.h
@@ -35,6 +35,7 @@ public:
 	vector<PWNode*> children;
 	bool hrcChangedSinceLastFlush = true;
 	bool addCalledSinceLastFlush = false;
+	bool becameInnerNodeSinceLastFlush = false;
 	PotreeWriter *potreeWriter;
 	vector<Point> cache;
 	int storeLimit = 20'000;

--- a/PotreeConverter/include/PotreeWriter.h
+++ b/PotreeConverter/include/PotreeWriter.h
@@ -33,7 +33,7 @@ public:
 	unsigned int numAccepted = 0;
 	PWNode *parent = NULL;
 	vector<PWNode*> children;
-	bool addedSinceLastFlush = true;
+	bool hrcChangedSinceLastFlush = true;
 	bool addCalledSinceLastFlush = false;
 	PotreeWriter *potreeWriter;
 	vector<Point> cache;

--- a/PotreeConverter/src/PotreeWriter.cpp
+++ b/PotreeConverter/src/PotreeWriter.cpp
@@ -153,6 +153,7 @@ PWNode *PWNode::createChild(int childIndex ){
 
 void PWNode ::split(){
 	children.resize(8, NULL);
+	becameInnerNodeSinceLastFlush = true;
 
 	string filepath = workDir() + "/data/" + path();
 	if(fs::exists(filepath)){
@@ -265,6 +266,7 @@ PWNode *PWNode::add(Point &point){
 			if(childIndex >= 0){
 				if(isLeafNode()){
 					children.resize(8, NULL);
+					becameInnerNodeSinceLastFlush = true;
 				}
 				PWNode *child = children[childIndex];
 
@@ -342,7 +344,7 @@ void PWNode::flush(){
 		}
 	}else{
 		if(addCalledSinceLastFlush){
-			writeToDisk(cache, true);
+			writeToDisk(cache, !becameInnerNodeSinceLastFlush);
 			//if(cache.size() != this->numAccepted){
 			//	cout << "cache " << cache.size() << " != " << this->numAccepted << " - " << this->name() << endl;
 			//
@@ -357,6 +359,7 @@ void PWNode::flush(){
 	}
 
 	addCalledSinceLastFlush = false;
+	becameInnerNodeSinceLastFlush = false;
 
 	for(PWNode *child : children){
 		if(child != NULL){


### PR DESCRIPTION
Under some conditions the hierarchy file would contain bad data.

Contents of r.hrc before patch:

```
        children | points
r     : 2        |    18
r2    : 2        |    78
r22   : 2        |   333
r222  : 2,3      |  1344
r2222 : 1,3,5,7  |  5507
r2223 : -        |     0
r22221: 3,7      |   639
r22223: 1,3,5    | 19074
r22225: 3        |  2565
r22227: -        |     0
```

actual data from .bin files:

```
        children | points
r     : 2        |    32
r2    : 2        |   144
r22   : 2        |   653
r222  : 2,3      |  2772
r2222 : 1,3,5,7  | 11463
r2223 : -        |   508
r22221: 3,7      |   912
r22223: 1,3,5,7  | 25520
r22225: 3,7      |  4711
r22227: 1,3,5,7  | 15963
```

r2223 is a leaf node with 508 points.
r22227 is an inner node with 15963 points itself and children 1, 3, 5 and 7

r.hrc file after patch:

```
        children | points
r     : 2        |    32
r2    : 2        |   144
r22   : 2        |   653
r222  : 2,3      |  2772
r2222 : 1,3,5,7  | 11460   // !
r2223 : -        |   508
r22221: 3,7      |   763   // !
r22223: 1,3,5,7  | 25515   // !
r22225: 3,7      |  4711
r22227: 1,3,5,7  | 15781   // !
```

I'm not sure where the remaining differences come from. I'll keep looking into it.

Binary files:
[r.hrc.zip](https://github.com/potree/PotreeConverter/files/559070/r.hrc.zip)
