### PR TITLE
Determine executable path based on arguments

### DIFF
--- a/PotreeConverter/include/PotreeConverter.h
+++ b/PotreeConverter/include/PotreeConverter.h
@@ -54,8 +54,9 @@ public:
 	bool edlEnabled = false;
 	bool showSkybox = false;
 	string material = "RGB";
+    string executablePath;
 
-	PotreeConverter(string workDir, vector<string> sources);
+    PotreeConverter(string executablePath, string workDir, vector<string> sources);
 		
 	void convert();
 

--- a/PotreeConverter/include/stuff.h
+++ b/PotreeConverter/include/stuff.h
@@ -105,8 +105,6 @@ bool copyDir(fs::path source, fs::path destination);
 
 float psign(float value);
 
-string getExecutablePath();
-
 }
 
 #endif

--- a/PotreeConverter/src/PotreeConverter.cpp
+++ b/PotreeConverter/src/PotreeConverter.cpp
@@ -79,7 +79,8 @@ PointReader *PotreeConverter::createPointReader(string path, PointAttributes poi
 	return reader;
 }
 
-PotreeConverter::PotreeConverter(string workDir, vector<string> sources){
+PotreeConverter::PotreeConverter(string executablePath, string workDir, vector<string> sources){
+    this->executablePath = executablePath;
 	this->workDir = workDir;
 	this->sources = sources;
 }
@@ -152,15 +153,13 @@ AABB PotreeConverter::calculateAABB(){
 
 void PotreeConverter::generatePage(string name){
 
-	string exePath = Potree::getExecutablePath();
-
 	string pagedir = this->workDir;
-	string templateSourcePath = exePath + "/resources/page_template/viewer_template.html";
-	string mapTemplateSourcePath = exePath + "/resources/page_template/lasmap_template.html";
+    string templateSourcePath = this->executablePath + "/resources/page_template/viewer_template.html";
+    string mapTemplateSourcePath = this->executablePath + "/resources/page_template/lasmap_template.html";
 	string templateTargetPath = pagedir + "/" + name + ".html";
 	string mapTemplateTargetPath = pagedir + "/lasmap_" + name + ".html";
 
-	Potree::copyDir(fs::path(exePath + "/resources/page_template"), fs::path(pagedir));
+    Potree::copyDir(fs::path(this->executablePath + "/resources/page_template"), fs::path(pagedir));
 	fs::remove(pagedir + "/viewer_template.html");
 	fs::remove(pagedir + "/lasmap_template.html");
 

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -76,6 +76,7 @@ struct Arguments{
 	bool edlEnabled = false;
 	bool showSkybox = false;
 	string material = "RGB";
+    string executablePath;
 };
 
 Arguments parseArguments(int argc, char **argv){
@@ -257,6 +258,9 @@ Arguments parseArguments(int argc, char **argv){
 		a.diagonalFraction = 200;
 	}
 
+    auto absolutePath = fs::canonical(fs::system_complete(argv[0]));
+    a.executablePath = absolutePath.parent_path().string();
+
 	return a;
 }
 
@@ -339,7 +343,7 @@ int main(int argc, char **argv){
 		Arguments a = parseArguments(argc, argv);
 		printArguments(a);
 
-		PotreeConverter pc(a.outdir, a.source);
+        PotreeConverter pc(a.executablePath, a.outdir, a.source);
 
 		pc.spacing = a.spacing;
 		pc.diagonalFraction = a.diagonalFraction;

--- a/PotreeConverter/src/stuff.cpp
+++ b/PotreeConverter/src/stuff.cpp
@@ -33,19 +33,6 @@ using std::vector;
 using std::binary_function;
 using std::map;
 
-
-#ifdef BOOST_OS_WINDOWS
-#include <Windows.h>
-#elif BOOST_OS_LINUX
-
-#elif BOOST_OS_MACOS
-
-#elif BOOST_OS_BSD
-
-#endif
-
-
-
 namespace Potree{
 
 /**
@@ -203,44 +190,6 @@ float psign(float value){
 	}else{
 		return 1.0;
 	}
-}
-
-
-
-// see http://stackoverflow.com/questions/1023306/finding-current-executables-path-without-proc-self-exe
-string getExecutablePath(){
-
-	string path = "./";
-	
-#ifdef BOOST_OS_WINDOWS
-	char  buffer[MAX_PATH]; 
-	GetModuleFileName( NULL, buffer, MAX_PATH );
-
-	string::size_type pos = string( buffer ).find_last_of( "\\/" );
-	path = string( buffer ).substr( 0, pos);
-#elif BOOST_OS_LINUX
-	// http://stackoverflow.com/questions/5525668/how-to-implement-readlink-to-find-the-path
-	char buff[PATH_MAX];
-    ssize_t len = ::readlink("/proc/self/exe", buff, sizeof(buff)-1);
-    if (len != -1) {
-      buff[len] = '\0';
-      path = string(buff);
-    }else{
-		cout << "WARNING: Potree was unable to determine to path to the executable." << endl;
-		cout << "Using current work dir as executable directory. Make sure to run potree inside the directory with the executable to avoid problems." << endl;
-	}
-//#elif BOOST_OS_MACOS
-	// TODO 
-	// http://stackoverflow.com/questions/799679/programatically-retrieving-the-absolute-path-of-an-os-x-command-line-app
-//#elif BOOST_OS_BSD
-	// TODO
-#else
-	cout << "WARNING: Potree was unable to identify the operating system and as a result, the directory of the executable." << endl;
-	cout << "Using current work dir as executable directory. Make sure to run potree inside the directory with the executable to avoid problems." << endl;
-	path = "./";
-#endif
-
-	return path;
 }
 
 }


### PR DESCRIPTION
Hi @m-schuetz 

This is the fix I propose for #228.
I had build issues on Linux and on macOS as well, and planned to fix it just like #233 did. I realized that probably we can get rid of the `getExecutablePath` function completely. 
Finding the path of the executable doesn't needs to be this complicated, there are simpler solutions. Although I agree that there is no bulletproof cross platform solution to this problem, but the solution in this PR should work in almost every situation except maybe for some exotic edge cases. The path is determined based on the first command line argument. This solution should work even if the executable is symlinked.