### PR TITLE
Using LAStools as a git submodule & fixed the build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "LAStools"]
+	path = LAStools
+	url = https://github.com/m-schuetz/LAStools.git

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ default: build
 
 .PHONY: LAStools
 LAStools:
-	[ -d $@ ] || git clone https://github.com/m-schuetz/LAStools.git
-	cd LAStools/LASzip && \
-	mkdir -p build && cd build && \
-	cmake -DCMAKE_BUILD_TYPE=Release .. && \
-	make -j$(nproc)
+	git submodule update --checkout
+	mkdir -p LAStools/LASzip/build && \
+	cd LAStools/LASzip/build && \
+	cmake --verbose -DCMAKE_BUILD_TYPE=Release ../src && \
+	make VERBOSE=1 -j$(nproc)
 
 .PHONY: build
 build: LAStools


### PR DESCRIPTION
The current make file uses `git clone` to load the `LAStools` dependencies which lacks the correct git commit _(in case there is an update)_ and make's it slightly less transparent what is happening. This PR mitigates this by using a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) instead.

Further I also found that the current make file doesn't work on Mac _(even with updated cmake & compilers)_. The few changes in this build script work well on my mac. I hope they don't break windows.