### PR TITLE
Add <functional> include

### DIFF
--- a/PotreeConverter/include/PotreeWriter.h
+++ b/PotreeConverter/include/PotreeWriter.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <functional>
 
 #include "AABB.h"
 #include "SparseGrid.h"


### PR DESCRIPTION
On the current master the project is not compiling with the latest GCC 7.1.1 on linux:

```
In file included from /home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeConverter.cpp:14:0:
/home/prior/repositories/PotreeConverter/PotreeConverter/include/PotreeWriter.h:78:21: error: ‘std::function’ has not been declared
  void traverse(std::function<void(PWNode*)> callback);
                     ^~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/include/PotreeWriter.h:78:29: error: expected ‘,’ or ‘...’ before ‘<’ token
  void traverse(std::function<void(PWNode*)> callback);
                             ^
/home/prior/repositories/PotreeConverter/PotreeConverter/include/PotreeWriter.h:80:33: error: ‘std::function’ has not been declared
  void traverseBreadthFirst(std::function<void(PWNode*)> callback);
                                 ^~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/include/PotreeWriter.h:80:41: error: expected ‘,’ or ‘...’ before ‘<’ token
  void traverseBreadthFirst(std::function<void(PWNode*)> callback);
                                         ^
/home/prior/repositories/PotreeConverter/PotreeConverter/src/stuff.cpp: In function ‘std::vector<std::__cxx11::basic_string<char> > Potree::split(std::__cxx11::string, std::vector<char>)’:
/home/prior/repositories/PotreeConverter/PotreeConverter/src/stuff.cpp:252:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  for (int i = 0; i < str.size(); i++) {
                  ~~^~~~~~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/stuff.cpp:263:12: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  if (start < str.size()) {
      ~~~~~~^~~~~~~~~~~~
In file included from /home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:25:0:
/home/prior/repositories/PotreeConverter/PotreeConverter/include/PotreeWriter.h:78:21: error: ‘std::function’ has not been declared
  void traverse(std::function<void(PWNode*)> callback);
                     ^~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/include/PotreeWriter.h:78:29: error: expected ‘,’ or ‘...’ before ‘<’ token
  void traverse(std::function<void(PWNode*)> callback);
                             ^
/home/prior/repositories/PotreeConverter/PotreeConverter/include/PotreeWriter.h:80:33: error: ‘std::function’ has not been declared
  void traverseBreadthFirst(std::function<void(PWNode*)> callback);
                                 ^~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/include/PotreeWriter.h:80:41: error: expected ‘,’ or ‘...’ before ‘<’ token
  void traverseBreadthFirst(std::function<void(PWNode*)> callback);
                                         ^
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp: In member function ‘void Potree::PWNode::flush()’:
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:280:7: error: ‘function’ is not a member of ‘std’
  std::function<void(vector<Point> &points, bool append)> writeToDisk = [&](vector<Point> &points, bool append){
       ^~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:280:7: note: suggested alternative: ‘is_function’
  std::function<void(vector<Point> &points, bool append)> writeToDisk = [&](vector<Point> &points, bool append){
       ^~~~~~~~
       is_function
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:280:55: error: expression list treated as compound expression in functional cast [-fpermissive]
  std::function<void(vector<Point> &points, bool append)> writeToDisk = [&](vector<Point> &points, bool append){
                                                       ^
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:280:16: error: expected primary-expression before ‘void’
  std::function<void(vector<Point> &points, bool append)> writeToDisk = [&](vector<Point> &points, bool append){
                ^~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:327:4: error: ‘writeToDisk’ was not declared in this scope
    writeToDisk(store, false);
    ^~~~~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeConverter.cpp: In function ‘void Potree::writeSources(std::__cxx11::string, std::vector<std::__cxx11::basic_string<char> >, std::vector<int>, std::vector<Potree::AABB>, std::__cxx11::string)’:
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeConverter.cpp:260:19: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  for(int i = 0; i < sourceFilenames.size(); i++){
                 ~~^~~~~~~~~~~~~~~~~~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:339:4: error: ‘writeToDisk’ was not declared in this scope
    writeToDisk(cache, true);
    ^~~~~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp: At global scope:
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:388:28: error: variable or field ‘traverse’ declared void
 void PWNode::traverse(std::function<void(PWNode*)> callback){
                            ^~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:388:28: error: ‘function’ is not a member of ‘std’
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:388:28: note: suggested alternative: ‘is_function’
 void PWNode::traverse(std::function<void(PWNode*)> callback){
                            ^~~~~~~~
                            is_function
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:388:37: error: expected primary-expression before ‘void’
 void PWNode::traverse(std::function<void(PWNode*)> callback){
                                     ^~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:398:40: error: variable or field ‘traverseBreadthFirst’ declared void
 void PWNode::traverseBreadthFirst(std::function<void(PWNode*)> callback){
                                        ^~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:398:40: error: ‘function’ is not a member of ‘std’
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:398:40: note: suggested alternative: ‘is_function’
 void PWNode::traverseBreadthFirst(std::function<void(PWNode*)> callback){
                                        ^~~~~~~~
                                        is_function
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:398:49: error: expected primary-expression before ‘void’
 void PWNode::traverseBreadthFirst(std::function<void(PWNode*)> callback){
                                                 ^~~~
In file included from /home/prior/repositories/PotreeConverter/PotreeConverter/src/main.cpp:13:0:
/home/prior/repositories/PotreeConverter/PotreeConverter/lib/arguments/arguments.hpp: In member function ‘std::vector<std::__cxx11::basic_string<char> > Argument::split(std::__cxx11::string, std::vector<char>)’:
/home/prior/repositories/PotreeConverter/PotreeConverter/lib/arguments/arguments.hpp:89:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < str.size(); i++) {
                   ~~^~~~~~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/lib/arguments/arguments.hpp:102:13: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (start < str.size()) {
       ~~~~~~^~~~~~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp: In member function ‘void Potree::PotreeWriter::flush()’:
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:636:4: error: invalid user-defined conversion from ‘Potree::PotreeWriter::flush()::<lambda(Potree::PWNode*)>’ to ‘int’ [-fpermissive]
   });
    ^
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:634:33: note: candidate is: Potree::PotreeWriter::flush()::<lambda(Potree::PWNode*)>::operator void (*)(Potree::PWNode*)() const <near match>
   root->traverse([](PWNode* node){
                                 ^
/home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:634:33: note:   no known conversion from ‘void (*)(Potree::PWNode*)’ to ‘int’
In file included from /home/prior/repositories/PotreeConverter/PotreeConverter/src/PotreeWriter.cpp:25:0:
/home/prior/repositories/PotreeConverter/PotreeConverter/include/PotreeWriter.h:78:7: note:   initializing argument 1 of ‘void Potree::PWNode::traverse(int)’
  void traverse(std::function<void(PWNode*)> callback);
       ^~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/lib/arguments/arguments.hpp: In member function ‘std::__cxx11::string Arguments::usage()’:
/home/prior/repositories/PotreeConverter/PotreeConverter/lib/arguments/arguments.hpp:259:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < argdefs.size(); i++) {
                   ~~^~~~~~~~~~~~~~~~
/home/prior/repositories/PotreeConverter/PotreeConverter/src/main.cpp: In function ‘void printArguments(PotreeArguments&)’:
/home/prior/repositories/PotreeConverter/PotreeConverter/src/main.cpp:245:19: warning: unused variable ‘s’ [-Wunused-variable]
   for(const auto &s : a.source) {
                   ^
make[3]: *** [PotreeConverter/CMakeFiles/PotreeConverter.dir/build.make:231: PotreeConverter/CMakeFiles/PotreeConverter.dir/src/PotreeWriter.cpp.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: *** [PotreeConverter/CMakeFiles/PotreeConverter.dir/build.make:207: PotreeConverter/CMakeFiles/PotreeConverter.dir/src/PotreeConverter.cpp.o] Error 1
make[3]: Leaving directory '/home/prior/repositories/PotreeConverter/build'
make[2]: *** [CMakeFiles/Makefile2:86: PotreeConverter/CMakeFiles/PotreeConverter.dir/all] Error 2
make[2]: Leaving directory '/home/prior/repositories/PotreeConverter/build'
make[1]: *** [Makefile:130: all] Error 2
make[1]: Leaving directory '/home/prior/repositories/PotreeConverter/build'
make: *** [Makefile:14: build] Error 2
```

This is fixed by adding the missing include.