### PR TITLE
Fix input file format detection.

### DIFF
--- a/PotreeConverter/src/stuff.cpp
+++ b/PotreeConverter/src/stuff.cpp
@@ -231,7 +231,7 @@ bool iEndsWith(const std::string &str, const std::string &suffix) {
 
 	auto tstr = str.substr(str.size() - suffix.size());
 
-	return icompare(tstr, suffix) == 0;
+	return icompare(tstr, suffix);
 }
 
 vector<string> split(string str, vector<char> delimiters) {


### PR DESCRIPTION
The non-boost replacement for [`iends_with`][iw] was consistently returning the opposite answer, leading to the [file type detection `if` block][ftd] always treating any input file as LAS-formatted.

[ftd]: https://github.com/potree/PotreeConverter/blob/master/PotreeConverter/src/PotreeConverter.cpp#L54
[iw]: http://www.boost.org/doc/libs/1_37_0/doc/html/boost/algorithm/iends_with.html