### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Builds a potree octree from las, laz, binary ply, xyz or ptx files.
 
 ## Build
 
-### linux / gcc 4.9
+### linux / gcc 5.3
 
 
 lastools (from fork with cmake)


### PR DESCRIPTION
PotreeConverter uses `<experimental/filesystem>` which isn't added to gcc until 5.3. Currently users are installing 4.9, crashing, then searching github issues and reinstalling the correct version. We can save everyone time by just putting it here.