### PR TITLE
Fix segfault and nondeterminism in command line argument parsing.

### DIFF
--- a/PotreeConverter/lib/arguments/arguments.hpp
+++ b/PotreeConverter/lib/arguments/arguments.hpp
@@ -283,14 +283,15 @@ public:
 
 	AValue get(string name) {
 		Argument *arg = getArgument(name);
+		vector<string> values;
 
 		for (auto entry : map) {
 			if (arg->is(entry.first)) {
-				return AValue(entry.second);
+				values.insert(values.end(), entry.second.begin(), entry.second.end());
 			}
 		}
 
-		return AValue({});
+		return AValue(values);
 	}
 
 

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -69,7 +69,7 @@ struct PotreeArguments {
 PotreeArguments parseArguments(int argc, char **argv){
 	Arguments args(argc, argv);
 
-	args.addArgument("source,i,", "input files");
+	args.addArgument("source,i,", "Source file. Can be LAS, LAZ, PTX or PLY");
 	args.addArgument("help,h", "prints usage");
 	args.addArgument("generate-page,p", "Generates a ready to use web page with the given name.");
 	args.addArgument("page-template", "directory where the web page template is located.");
@@ -89,7 +89,6 @@ PotreeArguments parseArguments(int argc, char **argv){
 	args.addArgument("source-listing-only", "Create a sources.json but no octree.");
 	args.addArgument("projection", "Specify projection in proj4 format.");
 	args.addArgument("list-of-files", "A text file containing a list of files to be converted.");
-	args.addArgument("source", "Source file. Can be LAS, LAZ, PTX or PLY");
 	args.addArgument("title", "Page title");
 	args.addArgument("description", "Description to be shown in the page.");
 	args.addArgument("edl-enabled", "Enable Eye-Dome-Lighting.");
@@ -213,6 +212,11 @@ PotreeArguments parseArguments(int argc, char **argv){
 			cerr << "ERROR: specified list of files not found: '" << a.listOfFiles << "'" << endl;
 			exit(1);
 		}
+	}
+	
+	if (a.source.empty()) {
+		cerr << "No input files specified" << endl;
+		exit(1);
 	}
 
 	a.title = args.get("title").as<string>();


### PR DESCRIPTION
There are two bugs fixed here that together led to segfaults with
command line arguments in certain orders.

The map of command line argument values is keyed by the argument flag,
or an empty string for the arguments preceding the first flag. When
looking up the values of an argument, the map is iterated, and the key
is checked against the list of flags defined for that argument.
Previously, the first matching value was returned, but this is
nondeterministic, since the unordered map does not have a defined
iteration order. With an argument list like "-i foo", it found the ""
key first, and returned an empty list. With other argument orders, the
unordered_map happened to find the "i" key first, and it worked.
Instead, this concatenates together the map entries for all defined
forms of the argument.

Second, this adds a check to bail out when no input files are passed,
rather than unconditionally accessing the first filename and segfaulting
if not present.

Fixes #274, Fixes #265, Fixes #293