### PR TITLE
Add support to pull in extended classifications when they are present.

### DIFF
--- a/PotreeConverter/include/LASPointReader.h
+++ b/PotreeConverter/include/LASPointReader.h
@@ -113,7 +113,7 @@ public:
 
         Point p = transform(coordinates[0], coordinates[1], coordinates[2]);
         p.intensity = point->intensity;
-        p.classification = point->classification;
+		p.classification = (point->classification ? point->classification : point->extended_classification);
 
         p.color.x = point->rgb[0] / colorScale;
         p.color.y = point->rgb[1] / colorScale;


### PR DESCRIPTION
This fixes a bug where extended classifications (now available in LAS 1.4 in point types of 6 and greater) would be realized in potree as 0.  This patch converts them to the proper 8 bit value.