### PR TITLE
Automatically set projection with WKT from LAS input

### DIFF
--- a/PotreeConverter/include/LASPointReader.h
+++ b/PotreeConverter/include/LASPointReader.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <iostream>
 #include <vector>
+#include <cstring>
 
 #include "laszip_api.h"
 
@@ -90,6 +91,20 @@ public:
 			return header->number_of_point_records;
 		}
 	}
+	
+	string getProjection() {
+		for (unsigned i = 0; i < header->number_of_variable_length_records; i++) {
+			laszip_vlr_struct* vlr = &header->vlrs[i];
+			string user_id(vlr->user_id);
+			
+			if ((user_id == "liblas" || user_id == "LASF_Projection") && vlr->record_id == 2112) {
+				char* wkt = (char*) vlr->data;
+				size_t len = strnlen(wkt, vlr->record_length_after_header);
+				return string(wkt, len);
+			}
+		}
+		return string("");
+	}
 
 	~LIBLASReader(){
 		laszip_close_reader(laszip_reader);
@@ -152,6 +167,8 @@ public:
 	Point getPoint();
 
 	AABB getAABB();
+	
+	string getProjection() { return reader->getProjection(); }
 
 	long long numPoints();
 

--- a/PotreeConverter/include/PointReader.h
+++ b/PotreeConverter/include/PointReader.h
@@ -4,6 +4,7 @@
 #define POINTREADER_H
 
 #include <experimental/filesystem>
+#include <string>
 
 #include "Point.h"
 #include "AABB.h"
@@ -22,7 +23,9 @@ public:
 	virtual Point getPoint() = 0;
 
 	virtual AABB getAABB() = 0;
-
+	
+	virtual std::string getProjection() { return ""; }
+	
 	virtual long long numPoints() = 0;
 
 	virtual void close() = 0;

--- a/PotreeConverter/src/PotreeConverter.cpp
+++ b/PotreeConverter/src/PotreeConverter.cpp
@@ -412,6 +412,17 @@ void PotreeConverter::convert(){
 		boundingBoxes.push_back(reader->getAABB());
 		numPoints.push_back(reader->numPoints());
 		sourceFilenames.push_back(fs::path(source).filename().string());
+		
+		string readerProjection = reader->getProjection();
+		if (!readerProjection.empty()) {
+			if (this->projection.empty()) {
+				cout << "Using projection: " << readerProjection << std::endl;
+				this->projection = readerProjection;
+				writer->setProjection(readerProjection);
+			} else if (this->projection != readerProjection) {
+				cout << "Ignoring projection: " << readerProjection << std::endl;
+			}
+		}
 
 		writeSources(this->workDir, sourceFilenames, numPoints, boundingBoxes, this->projection);
 		if(this->sourceListingOnly){


### PR DESCRIPTION
LAS files contain a projection in WKT format. The proj4js library
currently used in the potree viewer has limited support for parsing WKT,
but it is improved in more recent versions.