### PR TITLE
Fixed problem with PTS/XYZ files where the RGB point colour is not co…

### DIFF
--- a/PotreeConverter/include/XYZPointReader.hpp
+++ b/PotreeConverter/include/XYZPointReader.hpp
@@ -97,7 +97,7 @@ public:
 				}
 
 				int i = 0;
-				for(const auto &f : format) {
+				for(const auto &f : this->format) {
 					string token = tokens[i++];
 					if(f == 'r'){
 						max = std::max(max, stof(token));


### PR DESCRIPTION
Fix #356 
When a color format is not supplied from the command line, the application tries to guess the file format but the variable "format" is used instead of "this->format" resulting in wrong color scale and offset values.