### PR TITLE
Now image is OK and build actually starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.10
+FROM ubuntu:16.04
 
 RUN apt-get update && apt-get install -y g++ git cmake libboost-all-dev
 RUN mkdir /data


### PR DESCRIPTION
I tried to build using the dockerfile, got

```
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/wily/main/source/Sources  404  Not Found [IP: 91.189.88.31 80]
[...]
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/wily-security/universe/binary-amd64/Packages  404  Not Found [IP: 91.189.88.31 80]

E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update && apt-get install -y g++ git cmake libboost-all-dev' returned a non-zero code: 100
```

Update to the stable 16.04 release means the first image layers are completed and build actually starts, I get:
```
[ 25%] Building CXX object PotreeConverter/CMakeFiles/PotreeConverter.dir/src/BINPointReader.cpp.o
/data/PotreeConverter/PotreeConverter/src/BINPointReader.cpp: In member function 'virtual bool Potree::BINPointReader::readNextPoint()':
/data/PotreeConverter/PotreeConverter/src/BINPointReader.cpp:182:64: error: 'memcpy' was not declared in this scope
     memcpy(target.data(), (buffer + offset), attribute.byteSize);
                                                                ^
PotreeConverter/CMakeFiles/PotreeConverter.dir/build.make:110: recipe for target 'PotreeConverter/CMakeFiles/PotreeConverter.dir/src/BINPointReader.cpp.o' failed
make[2]: *** [PotreeConverter/CMakeFiles/PotreeConverter.dir/src/BINPointReader.cpp.o] Error 1
CMakeFiles/Makefile2:85: recipe for target 'PotreeConverter/CMakeFiles/PotreeConverter.dir/all' failed
make[1]: *** [PotreeConverter/CMakeFiles/PotreeConverter.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
The command '/bin/sh -c cd build && make' returned a non-zero code: 2
```
but at least compile starts