### PR TITLE
Fixing so it will compile on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@ project(Potree)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
-#if(UNIX)
-#    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++17 -pthread -lstdc++ -lstdc++fs -lm")
-#    SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -lstdc++fs" )
-#endif()
+SET(CMAKE_CXX_STANDARD 17)
 
 add_subdirectory(PotreeConverter)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,25 @@
-FROM ubuntu:15.10
+FROM ubuntu:bionic
 
-RUN apt-get update && apt-get install -y g++ git cmake libboost-all-dev
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y g++-8 git cmake libboost-all-dev
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 RUN mkdir /data
 
 WORKDIR /data
 
-RUN git clone https://github.com/m-schuetz/LAStools.git
-WORKDIR /data/LAStools/LASzip
-RUN mkdir build
-RUN cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
-RUN cd build && make
+RUN git clone https://github.com/LAStools/LAStools.git
+WORKDIR /data/LAStools/
+RUN make && cd LASzip && cmake . -DCMAKE_BUILD_TYPE=Release \
+    && make && make install
 
 RUN mkdir ./PotreeConverter
 WORKDIR /data/PotreeConverter
 ADD . /data/PotreeConverter
-RUN mkdir build
-RUN cd build && cmake -DCMAKE_BUILD_TYPE=Release -DLASZIP_INCLUDE_DIRS=/data/LAStools/LASzip/dll -DLASZIP_LIBRARY=/data/LAStools/LASzip/build/src/liblaszip.so .. 
-RUN cd build && make
-RUN cp -R /data/PotreeConverter/PotreeConverter/resources/ /data
-
+RUN mkdir build && cd build && cmake \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLASZIP_INCLUDE_DIRS=/usr/local/include/laszip/ \
+            -DLASZIP_LIBRARY=/usr/local/lib/liblaszip.so .. \  
+    && make

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y g++-8 git cmake libboost-all-dev
+RUN apt-get update && apt-get install -y --no-install-recommends g++-8 git build-essential cmake make ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# gcc-8 is required for new c++17 headers used in Potree Converter
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 RUN mkdir /data
 
@@ -10,8 +13,8 @@ WORKDIR /data
 
 RUN git clone https://github.com/LAStools/LAStools.git
 WORKDIR /data/LAStools/
-RUN make && cd LASzip && cmake . -DCMAKE_BUILD_TYPE=Release \
-    && make && make install
+RUN cd LASzip && cmake . -DCMAKE_BUILD_TYPE=Release \
+    && make && make install && cd ../.. && rm -rf LAStools
 
 RUN mkdir ./PotreeConverter
 WORKDIR /data/PotreeConverter

--- a/PotreeConverter/src/BINPointReader.cpp
+++ b/PotreeConverter/src/BINPointReader.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <filesystem>
+#include <cstring>
 
 #include "BINPointReader.hpp"
 #include "stuff.h"
@@ -15,6 +16,7 @@ using std::cout;
 using std::endl;
 using std::vector;
 using std::ios;
+using std::memcpy;
 
 namespace Potree{
 

--- a/PotreeConverter/src/PotreeWriter.cpp
+++ b/PotreeConverter/src/PotreeWriter.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <fstream>
 #include <iomanip>
+#include <cstring>
 
 #include <filesystem>
 
@@ -30,6 +31,7 @@ using std::stringstream;
 using std::chrono::high_resolution_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;
+using std::memcpy;
 
 namespace fs = std::filesystem;
 
@@ -295,7 +297,8 @@ void PWNode::flush(){
 			if(fs::exists(temppath)){
 				PointReader *reader = createReader(temppath);
 				while(reader->readNextPoint()){
-					writer->write(reader->getPoint());
+					auto point = reader->getPoint();
+					writer->write(point);
 				}
 				reader->close();
 				delete reader;


### PR DESCRIPTION
* Added C++17 flags so will compile with gcc8+ using `<filesystem>`
* Added `#include <cstring>` in files using `memcpy`
* Added `using std::memcpy`
* Fixed 'non-const reference cannot bind to a temporary object' compiler
error that is ignored by MSVC compiler extension but not GCC.

Do not have windows environment to confirm changes do not break on Windows. 