### PR TITLE
Fix Sanity Check Double Checking X Value

### DIFF
--- a/Converter/src/main.cpp
+++ b/Converter/src/main.cpp
@@ -259,7 +259,7 @@ Stats computeStats(vector<Source> sources){
 	cout << "total file size: " << strTotalFileSize << endl;
 
 	{ // sanity check
-		bool sizeError = (size.x == 0.0) || (size.x == 0.0) || (size.z == 0);
+		bool sizeError = (size.x == 0.0) || (size.y == 0.0) || (size.z == 0);
 		if (sizeError) {
 			logger::ERROR("invalid bounding box. at least one axis has a size of zero.");
 


### PR DESCRIPTION
Quick fix for sanity check. Checks X, Y, and Z instead of accidentally checking X twice.

Side note: 

Since this is a good check to have for any input, maybe the error log should have correct capitalization. There is a non-trivial chance of someone seeing this error message if they have an out-of-spec / corrupt file.