### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:21.04 AS build
+
+RUN apt-get update
+RUN apt-get -y install cmake g++ git libtbb-dev
+
+RUN mkdir /data
+WORKDIR /data
+
+ADD . /data
+RUN mkdir build 
+WORKDIR /data/build
+RUN cmake ../ && make
+
+# copy liblaszip.so to tmp directory
+RUN ldd /data/build/PotreeConverter | grep 'liblaszip.so' | awk '{print $3}' | xargs -I '{}' cp -v '{}' /tmp/
+
+FROM ubuntu:21.04
+
+RUN apt-get update && apt-get -y install libtbb-dev
+
+# copy dependencies
+COPY --from=build /tmp/liblaszip.so* /usr/lib
+
+# copy binary
+COPY --from=build /data/build/PotreeConverter /data/build/PotreeConverter
+
+# copy page template
+COPY --from=build /data/build/resources /data/build/resources
+
+ENTRYPOINT ["/data/build/PotreeConverter"]


### PR DESCRIPTION
This PR adds a basic Dockerfile that can be used to build a Docker image for PotreeConverter v2. 

Some people seemed to have difficulties dockerizing PotreeConverter v2 (as mentioned in #448) so this might be helpful for them. 