### PR TITLE
Add Help Message for Options

### DIFF
--- a/Converter/src/main.cpp
+++ b/Converter/src/main.cpp
@@ -20,17 +20,17 @@ using namespace std;
 Options parseArguments(int argc, char** argv) {
 	Arguments args(argc, argv);
 
-	args.addArgument("source,i,", "input files");
-	args.addArgument("outdir,o", "output directory");
-	args.addArgument("encoding", "Encoding type. \"BROTLI\", \"UNCOMPRESSED\"");
-	args.addArgument("method,m", "sampling method");
-	args.addArgument("chunkMethod", "chunking method");
-	args.addArgument("keep-chunks", "");
-	args.addArgument("no-chunking", "");
-	args.addArgument("no-indexing", "");
-	args.addArgument("attributes", "attributes in output file");
-	args.addArgument("generate-page,p", "Generates a ready to use web page with the given name.");
-	args.addArgument("title", "Page title");
+	args.addArgument("source,i", "Input files");
+	args.addArgument("outdir,o", "Output directory");
+	args.addArgument("encoding", "Encoding type \"BROTLI\", \"UNCOMPRESSED\" (default)");
+	args.addArgument("method,m", "Point sampling method \"poisson\", \"poisson_average\", \"random\"");
+	args.addArgument("chunkMethod", "Chunking method");
+	args.addArgument("keep-chunks", "Skip deleting temporary chunks during conversion");
+	args.addArgument("no-chunking", "Disable chunking phase");
+	args.addArgument("no-indexing", "Disable indexing phase");
+	args.addArgument("attributes", "Attributes in output file");
+	args.addArgument("generate-page,p", "Generate a ready to use web page with the given name");
+	args.addArgument("title", "Page title used when generating a web page");
 
 
 	if(!args.has("source")) {

--- a/Converter/src/main.cpp
+++ b/Converter/src/main.cpp
@@ -21,6 +21,7 @@ Options parseArguments(int argc, char** argv) {
 	Arguments args(argc, argv);
 
 	args.addArgument("source,i", "Input files");
+	args.addArgument("help,h", "Display help information");
 	args.addArgument("outdir,o", "Output directory");
 	args.addArgument("encoding", "Encoding type \"BROTLI\", \"UNCOMPRESSED\" (default)");
 	args.addArgument("method,m", "Point sampling method \"poisson\", \"poisson_average\", \"random\"");
@@ -32,6 +33,11 @@ Options parseArguments(int argc, char** argv) {
 	args.addArgument("generate-page,p", "Generate a ready to use web page with the given name");
 	args.addArgument("title", "Page title used when generating a web page");
 
+	if (args.has("help")) {
+		cout << "/Converter <source> -o <outdir>" << endl;
+		cout << args.usage() << endl;
+		exit(0);
+	}
 
 	if(!args.has("source")) {
 		cout << "/Converter <source> -o <outdir>" << endl;

--- a/Converter/src/main.cpp
+++ b/Converter/src/main.cpp
@@ -20,7 +20,7 @@ using namespace std;
 Options parseArguments(int argc, char** argv) {
 	Arguments args(argc, argv);
 
-	args.addArgument("source,i", "Input files");
+	args.addArgument("source,i,", "Input file(s)");
 	args.addArgument("help,h", "Display help information");
 	args.addArgument("outdir,o", "Output directory");
 	args.addArgument("encoding", "Encoding type \"BROTLI\", \"UNCOMPRESSED\" (default)");

--- a/Converter/src/main.cpp
+++ b/Converter/src/main.cpp
@@ -34,13 +34,13 @@ Options parseArguments(int argc, char** argv) {
 	args.addArgument("title", "Page title used when generating a web page");
 
 	if (args.has("help")) {
-		cout << "/Converter <source> -o <outdir>" << endl;
+		cout << "PotreeConverter <source> -o <outdir>" << endl;
 		cout << args.usage() << endl;
 		exit(0);
 	}
 
 	if(!args.has("source")) {
-		cout << "/Converter <source> -o <outdir>" << endl;
+		cout << "PotreeConverter <source> -o <outdir>" << endl;
 
 		exit(1);
 	}
@@ -48,7 +48,7 @@ Options parseArguments(int argc, char** argv) {
 	vector<string> source = args.get("source").as<vector<string>>();
 
 	if (source.size() == 0) {
-		cout << "/Converter <source> -o <outdir>" << endl;
+		cout << "PotreeConverter <source> -o <outdir>" << endl;
 
 		exit(1);
 	}

--- a/Converter/src/main.cpp
+++ b/Converter/src/main.cpp
@@ -35,12 +35,13 @@ Options parseArguments(int argc, char** argv) {
 
 	if (args.has("help")) {
 		cout << "PotreeConverter <source> -o <outdir>" << endl;
-		cout << args.usage() << endl;
+		cout << endl << args.usage() << endl;
 		exit(0);
 	}
 
-	if(!args.has("source")) {
+	if (!args.has("source")) {
 		cout << "PotreeConverter <source> -o <outdir>" << endl;
+		cout << endl << "For a list of options, use --help or -h" << endl;
 
 		exit(1);
 	}
@@ -49,6 +50,7 @@ Options parseArguments(int argc, char** argv) {
 
 	if (source.size() == 0) {
 		cout << "PotreeConverter <source> -o <outdir>" << endl;
+		cout << endl << "For a list of options, use --help or -h" << endl;
 
 		exit(1);
 	}


### PR DESCRIPTION
The older PotreeConverter 1.7 had detailed argument listings on-demand. This PR adds that feature back to version 2. 
Tidied up the text a bit as well, e.g. the executable name.

Before these changes:

```
~>PotreeConverter.exe
#threads: 8
/Converter <source> -o <outdir>
```

After: 

```
~>PotreeConverter.exe
#threads: 8
PotreeConverter <source> -o <outdir>

For a list of options, use --help or -h
```

```
~>PotreeConverter.exe -h
#threads: 8
PotreeConverter <source> -o <outdir>

  -i [ --source ]         Input file(s)
  -h [ --help ]           Display help information
  -o [ --outdir ]         Output directory
  --encoding              Encoding type "BROTLI", "UNCOMPRESSED" (default)
  -m [ --method ]         Point sampling method "poisson", "poisson_average", "random"
  --chunkMethod           Chunking method
  --keep-chunks           Skip deleting temporary chunks during conversion
  --no-chunking           Disable chunking phase
  --no-indexing           Disable indexing phase
  --attributes            Attributes in output file
  -p [ --generate-page ]  Generate a ready to use web page with the given name
  --title                 Page title used when generating a web page

```

Added a few basic descriptions. They're just placeholders.