### PR TITLE
Fix min/max position not being correct due to multithreading

### DIFF
--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -736,7 +736,7 @@ namespace chunker_countsort_laszip {
 				auto attributeHandlers = createAttributeHandlers(header, data, point, inputAttributes, outputAttributesCopy);
 
 				double coordinates[3];
-				auto aPosition = outputAttributes.get("position");
+				auto aPosition = outputAttributesCopy.get("position");
 
 				for (int64_t i = 0; i < batchSize; i++) {
 					laszip_read_point(laszip_reader);


### PR DESCRIPTION
The code was in place to handle this:

```
			// merge min/max of this batch into global min/max
			for (int i = 0; i < outputAttributesCopy.list.size(); i++)
			{
				Attribute &source = outputAttributesCopy.list[i];
				Attribute &target = outputAttributes.list[i];

				lock_guard<mutex> lock(mtx_attributes);
				target.min.x = std::min(target.min.x, source.min.x);
				target.min.y = std::min(target.min.y, source.min.y);
				target.min.z = std::min(target.min.z, source.min.z);

				target.max.x = std::max(target.max.x, source.max.x);
				target.max.y = std::max(target.max.y, source.max.y);
				target.max.z = std::max(target.max.z, source.max.z);
			}
```

However, outputAttributesCopy min/max was never being set; instead, outputAttributes min/max we being assigned to directly. As a result, the code above did not do anything, and outputAttributes got improperly assigned/overriden by multiple threads.
