### PR TITLE
Adding support for overriding number of threads

### DIFF
--- a/Converter/include/chunker_countsort_laszip.h
+++ b/Converter/include/chunker_countsort_laszip.h
@@ -15,6 +15,14 @@ class State;
 
 namespace chunker_countsort_laszip {
 
+	inline auto numChunkerThreads() {
+		return getCpuData().numThreads;
+	}
+
+	inline auto numFlushThreads() {
+		return getCpuData().numThreads;
+	}
+
 	void doChunking(vector<Source> sources, string targetDir, Vector3 min, Vector3 max, State& state, Attributes outputAttributes);
 
 }

--- a/Converter/include/indexer.h
+++ b/Converter/include/indexer.h
@@ -47,7 +47,7 @@ namespace indexer{
 	constexpr int maxPointsPerChunk = 10'000;
 
 	inline int numSampleThreads() {
-		return getCpuData().numProcessors;
+		return getCpuData().numThreads;
 	}
 
 	struct Hierarchy {

--- a/Converter/modules/unsuck/unsuck.hpp
+++ b/Converter/modules/unsuck/unsuck.hpp
@@ -61,11 +61,14 @@ struct MemoryData {
 struct CpuData {
 	double usage = 0;
 	size_t numProcessors = 0;
+	size_t numThreads = 0;
 };
 
 MemoryData getMemoryData();
 
 CpuData getCpuData();
+
+void setNumThreadsOverride(size_t threads);
 
 void printMemoryReport();
 

--- a/Converter/modules/unsuck/unsuck_platform_specific.cpp
+++ b/Converter/modules/unsuck/unsuck_platform_specific.cpp
@@ -1,6 +1,11 @@
 
 #include "unsuck.hpp"
 
+static int numThreads;
+void setNumThreadsOverride(size_t numThreadsOverride) {
+	numThreads = numThreadsOverride;
+}
+
 #ifdef _WIN32
 	#include "TCHAR.h"
 	#include "pdh.h"
@@ -103,6 +108,7 @@ void init() {
 	GetSystemInfo(&sysInfo);
 	// numProcessors = sysInfo.dwNumberOfProcessors;
 	numProcessors = std::thread::hardware_concurrency();
+	numThreads = numProcessors;
 
 	GetSystemTimeAsFileTime(&ftime);
 	memcpy(&lastCPU, &ftime, sizeof(FILETIME));
@@ -141,6 +147,7 @@ CpuData getCpuData() {
 	CpuData data;
 	data.numProcessors = numProcessors;
 	data.usage = percent * 100.0;
+	data.numThreads = numThreads;
 
 	return data;
 }
@@ -304,7 +311,8 @@ static unsigned long long lastTotalUser, lastTotalUserLow, lastTotalSys, lastTot
 
 void init() {
 	numProcessors = std::thread::hardware_concurrency();
-	
+	numThreads = numProcessors;
+
 	FILE* file = fopen("/proc/stat", "r");
     fscanf(file, "cpu %llu %llu %llu %llu", &lastTotalUser, &lastTotalUserLow, &lastTotalSys, &lastTotalIdle);
     fclose(file);
@@ -352,6 +360,7 @@ CpuData getCpuData() {
 	CpuData data;
 	data.numProcessors = numProcessors;
 	data.usage = getCpuUsage();
+	data.numThreads = numThreads;
 
 	return data;
 }

--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -41,12 +41,6 @@ namespace fs = std::filesystem;
 
 namespace chunker_countsort_laszip {
 
-	auto numChunkerThreads = getCpuData().numProcessors;
-	auto numFlushThreads = getCpuData().numProcessors;
-
-	// auto numChunkerThreads = 1;
-	// auto numFlushThreads = 1;
-
 	int maxPointsPerChunk = 5'000'000;
 	int gridSize = 128;
 	mutex mtx_attributes;
@@ -263,7 +257,7 @@ namespace chunker_countsort_laszip {
 			//cout << ("end: " + formatNumber(dbgCurr)) << endl;
 		};
 
-		TaskPool<Task> pool(numChunkerThreads, processor);
+		TaskPool<Task> pool(numChunkerThreads(), processor);
 
 		auto tStartTaskAssembly = now();
 
@@ -650,7 +644,7 @@ namespace chunker_countsort_laszip {
 		state.bytesProcessed = 0;
 		state.duration = 0;
 
-		writer = new ConcurrentWriter(numFlushThreads, state);
+		writer = new ConcurrentWriter(numFlushThreads(), state);
 
 		printElapsedTime("distributePoints0", tStart);
 
@@ -899,7 +893,7 @@ namespace chunker_countsort_laszip {
 
 		};
 
-		TaskPool<Task> pool(numChunkerThreads, processor);
+		TaskPool<Task> pool(numChunkerThreads(), processor);
 
 		for (auto source: sources) {
 

--- a/Converter/src/main.cpp
+++ b/Converter/src/main.cpp
@@ -32,6 +32,7 @@ Options parseArguments(int argc, char** argv) {
 	args.addArgument("attributes", "Attributes in output file");
 	args.addArgument("generate-page,p", "Generate a ready to use web page with the given name");
 	args.addArgument("title", "Page title used when generating a web page");
+	args.addArgument("threads,t", "Overrides the default number of threads setting based on number of CPU cores");
 
 	if (args.has("help")) {
 		cout << "PotreeConverter <source> -o <outdir>" << endl;
@@ -130,6 +131,20 @@ Options parseArguments(int argc, char** argv) {
 	options.keepChunks = keepChunks;
 	options.noChunking = noChunking;
 	options.noIndexing = noIndexing;
+
+	auto cpuData = getCpuData();
+	cout << "#threads: " << cpuData.numThreads << endl;
+
+	if (args.has("threads")) {
+		int threads = args.get("threads").as<int>();
+		if (threads > 0) {
+			cout << "Overriding #threads default to: " << threads << endl;
+			setNumThreadsOverride(threads);
+		} else {
+			cout << "Invalid number of threads specified: " << threads << endl;
+			exit(123);
+		}
+	}
 
 	//cout << "flags: ";
 	//for (string flag : options.flags) {
@@ -496,9 +511,6 @@ int main(int argc, char** argv) {
 	auto exePath = fs::canonical(fs::absolute(argv[0])).parent_path().string();
 
 	launchMemoryChecker(2 * 1024, 0.1);
-	auto cpuData = getCpuData();
-
-	cout << "#threads: " << cpuData.numProcessors << endl;
 
 	auto options = parseArguments(argc, argv);
 


### PR DESCRIPTION
Currently the number of CPU cores of the host running the converter is used to define the number of threads. This may not ideal for scenarios when not all CPU cores are allocated to the application.

My current use case is running the converter in a docker container:
* no matter how many CPU cores I allocate to the container, the number of threads will be fixed and based on total number of cores available in the host.

This PR adds support for defining the number of threads through command line parameter `-t [ --threads ]` , so that we're able to tweak the default setting.

