### PR TITLE
Fix build on Ubuntu 22.04: Missing #includes

### DIFF
--- a/Converter/include/DbgWriter.h
+++ b/Converter/include/DbgWriter.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <filesystem>
+#include <limits>
 
 #include "structures.h"
 

--- a/Converter/src/indexer.cpp
+++ b/Converter/src/indexer.cpp
@@ -2,6 +2,7 @@
 #include <cerrno>
 #include <execution>
 #include <algorithm>
+#include <limits>
 
 #include "indexer.h"
 


### PR DESCRIPTION
Fix missing #include <limits> in files that are using std::numeric_limits. This should fix the build failure on Ubuntu 22.04. 

This should fix https://github.com/potree/PotreeConverter/issues/566