### PR TITLE
Fix issue with duplicate points

### DIFF
--- a/Converter/src/indexer.cpp
+++ b/Converter/src/indexer.cpp
@@ -947,7 +947,7 @@ void buildHierarchy(Indexer* indexer, Node* node, shared_ptr<Buffer> points, int
 				vector<int64_t> distinct;
 				unordered_map<string, int> handled;
 
-				auto contains = [](auto map, auto key) {
+				auto contains = [](auto const & map, auto const & key) {
 					return map.find(key) != map.end();
 				};
 


### PR DESCRIPTION
I recently ran into an issue with a point cloud, where PotreeConvert would become stuck in the indexing phase at 100%. Basically, the symptoms are identical to issue #489.

After some debugging, it got clear that potree detected many duplicate points in the file and was trying to deduplicate them. This calls the `contains(map, key)` helper for every single point in the current split. This helper takes the map of distinct points by value. Having to copy the map once for every point in the current split takes so long, that it seems like PotreeConvert runs 'forever'.

After changing the signature of `contains(map, key)` so that it takes its parameters by reference, the problem is gone.