### PR TITLE
Fix segfault when --attributes is used

### DIFF
--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -635,8 +635,8 @@ namespace chunker_countsort_laszip {
 					handlers.push_back(handleAttribute);
 				}
 
-				sourceOffset += attribute->size;
-				attributeOffset += attribute->size;
+				sourceOffset += attributeSize;
+				attributeOffset += attributeSize;
 			}
 
 		}


### PR DESCRIPTION
attributes->size was being used outside of the nullptr check