### PR TITLE
Fix bug where chunks containing exactly 10000 points are lost during indexing

### DIFF
--- a/Converter/src/indexer.cpp
+++ b/Converter/src/indexer.cpp
@@ -822,7 +822,7 @@ vector<NodeCandidate> createNodes(vector<vector<int64_t>>& pyramid) {
 // 4. Recursively repeat at 1. for identified nodes
 void buildHierarchy(Indexer* indexer, Node* node, shared_ptr<Buffer> points, int64_t numPoints, int64_t depth = 0) {
 
-	if (numPoints < maxPointsPerChunk) {
+	if (numPoints <= maxPointsPerChunk) {
 		Node* realization = node;
 		realization->indexStart = 0;
 		realization->numPoints = numPoints;


### PR DESCRIPTION
This is most likely the cause behind issue https://github.com/potree/PotreeConverter/issues/597

Before this fix, the created octree.bin is 10000 * bits_per_point bytes smaller than it should be according to the point count and bits per point in the created metadata.json. Thus, the resulting potree point cloud contains 10000 points less than the input las file and than what it says in the metadata.json file.

When the indexer builds the hierarchy, this bug caused recursion to stop when encountering a chunk containing exactly 10000 points, neither recursing down into parts of the chunk nor writing the chunk out to the octree.bin file.

Unfortunately I can not publish the las input files that are affected by this bug.