### PR TITLE
Fix introduction of decimal errors due to double decimal precision using BROTLI

### DIFF
--- a/Converter/include/sampler_poisson.h
+++ b/Converter/include/sampler_poisson.h
@@ -179,8 +179,7 @@ struct SamplerPoisson : public Sampler {
 
 			};
 
-			auto parallel = std::execution::par_unseq;
-			std::sort(parallel, points.begin(), points.end(), [center](Point a, Point b) -> bool {
+			std::sort(points.begin(), points.end(), [center](Point a, Point b) -> bool {
 
 				auto ax = a.x - center.x;
 				auto ay = a.y - center.y;

--- a/Converter/include/sampler_poisson_average.h
+++ b/Converter/include/sampler_poisson_average.h
@@ -280,8 +280,7 @@ struct SamplerPoissonAverage : public Sampler {
 
 			};
 
-			auto parallel = std::execution::par_unseq;
-			std::sort(parallel, points.begin(), points.end(), [center](Point a, Point b) -> bool {
+			std::sort(points.begin(), points.end(), [center](Point a, Point b) -> bool {
 
 				auto ax = a.x - center.x;
 				auto ay = a.y - center.y;

--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -225,9 +225,9 @@ namespace chunker_countsort_laszip {
 					double y = coordinates[1];
 					double z = coordinates[2];
 
-					int32_t X = int32_t((x - posOffset.x) / posScale.x);
-					int32_t Y = int32_t((y - posOffset.y) / posScale.y);
-					int32_t Z = int32_t((z - posOffset.z) / posScale.z);
+					int32_t X = int32_t(std::round((x - posOffset.x) / posScale.x));
+					int32_t Y = int32_t(std::round((y - posOffset.y) / posScale.y));
+					int32_t Z = int32_t(std::round((z - posOffset.z) / posScale.z));
 
 					double ux = (double(X) * posScale.x + posOffset.x - min.x) / size.x;
 					double uy = (double(Y) * posScale.y + posOffset.y - min.y) / size.y;
@@ -778,9 +778,9 @@ namespace chunker_countsort_laszip {
 						double y = coordinates[1];
 						double z = coordinates[2];
 
-						int32_t X = int32_t((x - outputAttributes.posOffset.x) / scale.x);
-						int32_t Y = int32_t((y - outputAttributes.posOffset.y) / scale.y);
-						int32_t Z = int32_t((z - outputAttributes.posOffset.z) / scale.z);
+						int32_t X = int32_t(std::round((x - outputAttributes.posOffset.x) / scale.x));
+						int32_t Y = int32_t(std::round((y - outputAttributes.posOffset.y) / scale.y));
+						int32_t Z = int32_t(std::round((z - outputAttributes.posOffset.z) / scale.z));
 
 						memcpy(data + offset + 0, &X, 4);
 						memcpy(data + offset + 4, &Y, 4);

--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -237,17 +237,26 @@ namespace chunker_countsort_laszip {
 					inBox = inBox && ux <= 1.0 && uy <= 1.0 && uz <= 1.0;
 
 					if (!inBox) {
-						stringstream ss;
-						ss << "encountered point outside bounding box." << endl;
-						ss << "box.min: " << min.toString() << endl;
-						ss << "box.max: " << max.toString() << endl;
-						ss << "point: " << Vector3(x, y, z).toString() << endl;
-						ss << "file: " << path << endl;
-						ss << "PotreeConverter requires a valid bounding box to operate." << endl;
-						ss << "Please try to repair the bounding box, e.g. using lasinfo with the -repair_bb argument." << endl;
-						logger::ERROR(ss.str());
+						// Also check with unrounded bounding box
+						bool xInBox = x >= min.x && x <= min.x + size.x;
+						bool yInBox = y >= min.y && y <= min.y + size.y;
+						bool zInBox = z >= min.z && z <= min.z + size.z;
 
-						exit(123);
+						if (!(xInBox && yInBox && zInBox))
+						{
+							// Point truely outside bounding box
+							stringstream ss;
+							ss << "encountered point outside bounding box." << endl;
+							ss << "box.min: " << min.toString() << endl;
+							ss << "box.max: " << max.toString() << endl;
+							ss << "point: " << Vector3(x, y, z).toString() << endl;
+							ss << "file: " << path << endl;
+							ss << "PotreeConverter requires a valid bounding box to operate." << endl;
+							ss << "Please try to repair the bounding box, e.g. using lasinfo with the -repair_bb argument." << endl;
+							logger::ERROR(ss.str());
+
+							exit(123);
+						}
 					}
 
 					int64_t ix = int64_t(std::min(dGridSize * ux, dGridSize - 1.0));

--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -238,9 +238,10 @@ namespace chunker_countsort_laszip {
 
 					if (!inBox) {
 						// Also check with unrounded bounding box
-						bool xInBox = x >= min.x && x <= min.x + size.x;
-						bool yInBox = y >= min.y && y <= min.y + size.y;
-						bool zInBox = z >= min.z && z <= min.z + size.z;
+
+						bool xInBox = std::round(x / posScale.x) >= std::round(min.x / posScale.x) && std::round(x / posScale.x) <= std::round((min.x + size.x) / posScale.x);
+						bool yInBox = std::round(y / posScale.y) >= std::round(min.y / posScale.y) && std::round(y / posScale.y) <= std::round((min.y + size.y) / posScale.y);
+						bool zInBox = std::round(z / posScale.z) >= std::round(min.z / posScale.z) && std::round(z / posScale.z) <= std::round((min.z + size.z) / posScale.z);
 
 						if (!(xInBox && yInBox && zInBox))
 						{

--- a/Converter/src/indexer.cpp
+++ b/Converter/src/indexer.cpp
@@ -1162,9 +1162,9 @@ SoA toStructOfArrays(Node* node, Attributes attributes) {
 			};
 			vector<P> ps;
 			P min;
-			min.x = std::numeric_limits<int64_t>::max();
-			min.y = std::numeric_limits<int64_t>::max();
-			min.z = std::numeric_limits<int64_t>::max();
+			min.x = 0;
+			min.y = 0;
+			min.z = 0;
 		
 			for (int64_t i = 0; i < numPoints; i++) {
 


### PR DESCRIPTION
There is a problem in PotreeConverter that the coordinates (x, y and/or z) in the output differ in the last decimal from the input.

Consider the following example LAZ file (scale 0.001). It contains two points:
1. X: 1.000, Y: 2.000, Z: 3.000
2. X: 1.000, Y: 2.001, Z: 3.000

After conversion with PotreeConverter both points translate to X: 1.000, Y: 2.000, Z: 3.000.

This is due to the fact that Y of point 2 is read from LasZip as 2.0009999999.... Then with a cast to int32_t the last decimals are lost, and becomes 2.000. 

[decimal_error.zip](https://github.com/potree/PotreeConverter/files/10784233/decimal_error.zip)

This pull request fixes that by applying some rounding.