### PR TITLE
...

### DIFF
--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -644,10 +644,10 @@ namespace chunker_countsort_laszip {
 					};
 
 					handlers.push_back(handleAttribute);
+					attributeOffset += attribute->size;
 				}
 
-				sourceOffset += attribute->size;
-				attributeOffset += attribute->size;
+				sourceOffset += inputAttribute.size;
 			}
 
 		}


### PR DESCRIPTION
attribute can be nullptr, therefore attribute->size should be within the ```if(attribute != nullptr)``` clause.