### PR TITLE
Show error on files with more than uint32_max points, not supported by laszip

### DIFF
--- a/Converter/modules/LasLoader/LasLoader.cpp
+++ b/Converter/modules/LasLoader/LasLoader.cpp
@@ -102,6 +102,17 @@ LasHeader loadLasHeader(string path) {
 
 	result.numPoints = std::max(header->extended_number_of_point_records, uint64_t(header->number_of_point_records));
 
+	if (result.numPoints > UINT32_MAX)
+	{
+		cout << "ERROR: encountered input file (" 
+			 << path 
+			 << ") with " 
+			 << result.numPoints 
+			 << " points which is more than UINT_MAX number of points (4294967295), this is not supported by laszip (see https ://github.com/LASzip/LASzip/issues/76)" 
+			 << endl;
+		exit(123);
+	}
+
 	result.pointDataFormat = header->point_data_format;
 
 	int numVlrs = header->number_of_variable_length_records;


### PR DESCRIPTION
LasZip does not support it. When using seek_point the index will be casted to uint32 and thus for large files will be seeking from the start of the file again resulting in both missing points and duplicate points.

See https://github.com/LASzip/LASzip/issues/76.

