### PR TITLE
Allow initializing Annotation uuid as constructor parameter

### DIFF
--- a/resources/page_template/libs/potree/potree.js
+++ b/resources/page_template/libs/potree/potree.js
@@ -55670,7 +55670,7 @@
 			this._title = args.title || 'No Title';
 			this._description = args.description || '';
 			this.offset = new Vector3();
-			this.uuid = MathUtils.generateUUID();
+			this.uuid = args.uuid || MathUtils.generateUUID();
 
 			if (!args.position) {
 				this.position = null;
@@ -80592,8 +80592,10 @@ ENDSEC
 
 			let annotation = new Annotation({
 				position: [589748.270, 231444.540, 753.675],
-				title: "Annotation Title",
-				description: `Annotation Description`
+				title: args.title || "Annotation Title",
+				description: args.description || `Annotation Description`,
+				cameraPosition: args.cameraPosition || undefined,
+				cameraTarget: args.cameraTarget || undefined
 			});
 			this.dispatchEvent({type: 'start_inserting_annotation', annotation: annotation});
 


### PR DESCRIPTION


Hello, I am requesting this pull request for allowing initializing Annotation uuid as constructor parameter,

I have created a project where I am saving the annotation uuid, camera position, camera target in server database, when I load the annotation via http fetch request I would like to set these properties using constructor.

I have applied a similar logic in _startInsertion_ method of _AnnotationTool_ class.

There can be more use cases allowing initializing properties via constructor parameter.
