### PR TITLE
add a --fixbb option to compute an accurate bounding box 

### DIFF
--- a/Converter/include/chunker_countsort_laszip.h
+++ b/Converter/include/chunker_countsort_laszip.h
@@ -17,5 +17,5 @@ class State;
 namespace chunker_countsort_laszip {
 
 	void doChunking(vector<Source> sources, string targetDir, Vector3 min, Vector3 max, State& state, Attributes outputAttributes, Monitor* monitor);
-
+	void fixBoundingBox(vector<Source> sources, Vector3& min, Vector3& max, Attributes& outputAttributes);
 }

--- a/Converter/include/converter_utils.h
+++ b/Converter/include/converter_utils.h
@@ -173,5 +173,6 @@ struct Options {
 	bool keepChunks = false;
 	bool noChunking = false;
 	bool noIndexing = false;
+	bool fixbb = false;
 
 };


### PR DESCRIPTION
This should help with issue #429.

Bad (zero size) bounding boxes are generated by the Polycam iPhone app that can scan rooms with the inbuilt lidar.

It seems for such a trivial problem it shouldn't be necessary to invoke a whole different **lasinfo** app just to fix these 6 numbers, as advised in the error message. 

https://github.com/potree/PotreeConverter/blob/develop/Converter/src/chunker_countsort_laszip.cpp#L247