### PR TITLE
bounding box check using min/max, not scaled value in [0,1]

### DIFF
--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -220,21 +220,14 @@ namespace chunker_countsort_laszip {
 				laszip_get_coordinates(laszip_reader, coordinates);
 
 				{
-					// transfer las integer coordinates to new scale/offset/box values
 					double x = coordinates[0];
 					double y = coordinates[1];
 					double z = coordinates[2];
 
-					int32_t X = int32_t((x - posOffset.x) / posScale.x);
-					int32_t Y = int32_t((y - posOffset.y) / posScale.y);
-					int32_t Z = int32_t((z - posOffset.z) / posScale.z);
-
-					double ux = (double(X) * posScale.x + posOffset.x - min.x) / size.x;
-					double uy = (double(Y) * posScale.y + posOffset.y - min.y) / size.y;
-					double uz = (double(Z) * posScale.z + posOffset.z - min.z) / size.z;
-
-					bool inBox = ux >= 0.0 && uy >= 0.0 && uz >= 0.0;
-					inBox = inBox && ux <= 1.0 && uy <= 1.0 && uz <= 1.0;
+					const bool inBox =
+						x >= min.x && x <= max.x &&
+						y >= min.y && y <= max.y &&
+						z >= min.z && z <= max.z;
 
 					if (!inBox) {
 						stringstream ss;
@@ -249,6 +242,15 @@ namespace chunker_countsort_laszip {
 
 						exit(123);
 					}
+
+					// transfer las integer coordinates to new scale/offset/box values
+					int32_t X = int32_t((x - posOffset.x) / posScale.x);
+					int32_t Y = int32_t((y - posOffset.y) / posScale.y);
+					int32_t Z = int32_t((z - posOffset.z) / posScale.z);
+
+					double ux = (double(X) * posScale.x + posOffset.x - min.x) / size.x;
+					double uy = (double(Y) * posScale.y + posOffset.y - min.y) / size.y;
+					double uz = (double(Z) * posScale.z + posOffset.z - min.z) / size.z;
 
 					int64_t ix = int64_t(std::min(dGridSize * ux, dGridSize - 1.0));
 					int64_t iy = int64_t(std::min(dGridSize * uy, dGridSize - 1.0));

--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -213,6 +213,10 @@ namespace chunker_countsort_laszip {
 			auto posScale = outputAttributes.posScale;
 			auto posOffset = outputAttributes.posOffset;
 
+			// Scale is the resolution of the point coordinates, and LAZ round coordinates toward closest integer during quantization.
+			// Half of scale is used as the tolerance value to check if point in the bounding box.
+			auto tol = posScale / 2.0;
+
 			for (int i = 0; i < numToRead; i++) {
 				int64_t pointOffset = i * bpp;
 
@@ -225,9 +229,9 @@ namespace chunker_countsort_laszip {
 					double z = coordinates[2];
 
 					const bool inBox =
-						x >= min.x && x <= max.x &&
-						y >= min.y && y <= max.y &&
-						z >= min.z && z <= max.z;
+						x > (min.x - tol.x) && x < (max.x + tol.x) &&
+						y > (min.y - tol.y) && y < (max.y + tol.y) &&
+						z > (min.z - tol.z) && z < (max.z + tol.z);
 
 					if (!inBox) {
 						stringstream ss;


### PR DESCRIPTION
I have a LAZ file being rejected due to the bounding box check. I did verified the bounding box using `lasinfo` which shows no point is outside bounding box.

The bounding box check code did not compare `xyz` to the original `min/max`, instead it compared scaled `ux/uy/uz` to `[0,1]`. Due to the double decimal precision, a tiny error could be introduced and make `ux>1` causing converter reject the LAZ file. Even the x is inside the original min/max, and no error reported by `lasinfo`.

It would make sense to check the bounding box to use `min/max` to avoid any decimal precision error introduced using the scaled values.