### PR TITLE
chore: remove font size settings for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -90,7 +90,6 @@
 		"stop_token": "cpp"
 	},
 	"files.trimTrailingWhitespace": false,
-	"editor.fontSize": 28,
 	"editor.autoIndent": "advanced",
 	"editor.detectIndentation": false,
 	"editor.insertSpaces": false,


### PR DESCRIPTION
You can set this up in your personal settings.