### PR TITLE
BUG FIX: Extra LAS field properly copied when --attributes specified

### DIFF
--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -573,7 +573,10 @@ namespace chunker_countsort_laszip {
 
 			int attributeOffset = 0;
 			for (int i = 0; i < firstExtraIndex; i++) {
-				attributeOffset += inputAttributes.list[i].size;
+				bool isIncludedInOutput = outputAttributes.get(inputAttributes.list[i].name) != nullptr;
+				if (isIncludedInOutput) {
+					attributeOffset += inputAttributes.list[i].size;
+				}
 			}
 
 			for (int i = firstExtraIndex; i < inputAttributes.list.size(); i++) {


### PR DESCRIPTION
Extra/non-standard LAS attributes are properly copied when `--attributes` flag is specified

## Criteria to create the bug that this PR Fixes

* The `--attributes` flag is specified
* The number of attributes provided is less than what's in the original cloud (most cases)
* One or more of the attributes specified is a custom attribute not apart of the standard LAS Point Record.

