### PR TITLE
Fix memory leak.

### DIFF
--- a/Converter/include/sampler_poisson.h
+++ b/Converter/include/sampler_poisson.h
@@ -179,8 +179,7 @@ struct SamplerPoisson : public Sampler {
 
 			};
 
-			auto parallel = std::execution::par_unseq;
-			std::sort(parallel, points.begin(), points.end(), [center](Point a, Point b) -> bool {
+			std::sort(points.begin(), points.end(), [center](Point a, Point b) -> bool {
 
 				auto ax = a.x - center.x;
 				auto ay = a.y - center.y;

--- a/Converter/include/sampler_poisson_average.h
+++ b/Converter/include/sampler_poisson_average.h
@@ -280,8 +280,7 @@ struct SamplerPoissonAverage : public Sampler {
 
 			};
 
-			auto parallel = std::execution::par_unseq;
-			std::sort(parallel, points.begin(), points.end(), [center](Point a, Point b) -> bool {
+			std::sort(points.begin(), points.end(), [center](Point a, Point b) -> bool {
 
 				auto ax = a.x - center.x;
 				auto ay = a.y - center.y;


### PR DESCRIPTION
When indexing large point clouds, we always had problems with PotreeConverter consuming enormous amounts of memory. PotreeConverter would only run with 100GiB of swap memory, if not more. 

Long and thorough investigations revealed the issue: The poisson sampling sorts the points by their distance to the center of the node. This is done using std::sort with the relatively new (C++17) std::execution::par_unseq argument so the sorting happens in parallel. In Linux, the C++ standard library relies on Intel TBB for the implementation of the parallel sorting. The TBB library is where the memory is leaking. 

There is not much information available online about this, but I think this is the issue that is causing the leak: https://community.intel.com/t5/Intel-oneAPI-Threading-Building/std-sort-std-execution-par-unseq-has-a-memory-leak-on-Linux/m-p/1582773

The fix for PotreeConverter is to simply not use par_unseq when sorting the points. This means that the sorting won't happen in parallel any more. However PotreeConverter already parallelizes over the chunks, so it should not be an issue.

We tested the fix with a point cloud consisting of approximately 100GB of uncompressed LAS files. In the current version of PotreeConverter you can see the memory climbing up to ~60GB during the indexing phase, while it stays below 12GB with the fix:

Old:
![Figure_1](https://github.com/user-attachments/assets/d558d8eb-32c7-473c-b97c-c9b64d904409)

New (fixed):
![Figure_2](https://github.com/user-attachments/assets/18683dfa-765f-403e-b6c0-01fcd4da83e8)

A positive side effect of this fix is, that it is also faster - possibly due to the reduced parallelisation overhead. In the example above, the indexing step was faster by factor 2.2, which saved us almost an hour of processing time.

I believe, that this PR will probably fix issue #528.