### PR TITLE
cmake: Don't force Release build. Fixes -DCMAKE_RELAEASE_TYPE not working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,12 @@ project(PotreeConverter LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+
+# Set the default build type in a way that keeps it overridable from the CLI.
+# From: https://stackoverflow.com/questions/48832233/have-a-cmake-project-default-to-the-release-build-type/48832234#48832234
+if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+endif()
 
 #message(${PROJECT_SOURCE_DIR})
 

--- a/Converter/libs/laszip/CMakeLists.txt
+++ b/Converter/libs/laszip/CMakeLists.txt
@@ -41,7 +41,11 @@ target_include_directories(laszip PRIVATE
 	../
 )
 
-set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+# Set the default build type in a way that keeps it overridable from the CLI.
+# From: https://stackoverflow.com/questions/48832233/have-a-cmake-project-default-to-the-release-build-type/48832234#48832234
+if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+endif()
 
 add_compile_definitions(OPENCV_VERSION=${OpenCV_VERSION})
 add_compile_definitions(_CRT_SECURE_NO_DEPRECATE)


### PR DESCRIPTION
That made packaging and debugging hell for distros and users, see e.g. https://github.com/potree/PotreeConverter/issues/450#issuecomment-692494951

Also fix that `Converter/libs/brotli/CMakeLists.txt` overrode the build type globally again.

Note that there seems to be no global consensus on how to just set the default bulid type in CMake:

* https://cmake.org/pipermail/cmake/2008-September/023808.html
* https://stackoverflow.com/questions/23907679/cmake-ignores-d-cmake-build-type-debug
* https://blog.kitware.com/cmake-and-the-default-build-type/
* https://stackoverflow.com/questions/48832233/have-a-cmake-project-default-to-the-release-build-type

So this commit arbitrarily chooses one way that at least isn't absolutely wrong.