### PR TITLE
Fix compile error for libc++ (e.g. Android & macOS), and clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,14 +54,8 @@ target_include_directories(PotreeConverter PRIVATE "./Converter/libs")
 
 
 if (UNIX)
-	find_package(Threads REQUIRED)
 	find_package(TBB REQUIRED)
-	
-	target_link_libraries(${PROJECT_NAME} Threads::Threads)
-	target_link_libraries(${PROJECT_NAME} tbb)
-
-
-	#SET(CMAKE_CXX_FLAGS "-pthread -ltbb")
+	target_link_libraries(${PROJECT_NAME} TBB::tbb)
 endif (UNIX)
 
 ###############################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,11 +52,25 @@ target_include_directories(PotreeConverter PRIVATE "./Converter/include")
 target_include_directories(PotreeConverter PRIVATE "./Converter/modules")
 target_include_directories(PotreeConverter PRIVATE "./Converter/libs")
 
+include(CheckCXXSymbolExists)
+set(_quiet_flag ${CMAKE_REQUIRED_QUIET})
+set(CMAKE_REQUIRED_QUIET TRUE)
+check_cxx_symbol_exists(_LIBCPP_VERSION "version" LIBCPP)
+check_cxx_symbol_exists(__GLIBCXX__ "version" GLIBCXX)
+set(CMAKE_REQUIRED_QUIET ${_quiet_flag})
+unset(_quiet_flag)
 
-if (UNIX)
+if (LIBCPP) # libc++
+	message(WARNING "libc++ parallel STL is still in working. See https://libcxx.llvm.org/Status/PSTL.html")
+	target_compile_options(${PROJECT_NAME} PRIVATE "-fexperimental-library")
+	target_link_options(${PROJECT_NAME} PRIVATE "-fexperimental-library")
+elseif (GLIBCXX) # libstdc++
+	message(WARNING "TBB is used as backend of parallel algorithm in c++17. See https://gcc.gnu.org/onlinedocs/libstdc++/manual/parallel_mode.html")
+	# The libstdc++ parallel mode is an experimental parallel implementation of many algorithms of the C++ Standard Library.
+	# OpenMP or TBB can be used as a backend.
 	find_package(TBB REQUIRED)
 	target_link_libraries(${PROJECT_NAME} TBB::tbb)
-endif (UNIX)
+endif()
 
 ###############################################
 # COPY PAGE TEMPLATE TO BINARY DIRECTORY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_SUPPRESS_REGENERATION true)
 
-project(PotreeConverter LANGUAGES CXX)
+project(PotreeConverter
+	VERSION 2.0
+	HOMEPAGE_URL "http://potree.org/"
+	LANGUAGES CXX
+)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -119,3 +123,32 @@ add_custom_command(
 		${PROJECT_SOURCE_DIR}/README.md
 		$<TARGET_FILE_DIR:${PROJECT_NAME}>/README.md)
 
+
+include(GNUInstallDirs)
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(FILES ${PROJECT_SOURCE_DIR}/LICENSE
+	RENAME license_potree_converter.txt
+	DESTINATION ${CMAKE_INSTALL_BINDIR}/licenses
+)
+
+install(FILES ${LASZIP_DIR}/COPYING
+	RENAME license_laszip.txt
+	DESTINATION ${CMAKE_INSTALL_BINDIR}/licenses
+)
+install(FILES ${BROTLI_DIR}/LICENSE
+	RENAME license_brotli.txt
+	DESTINATION ${CMAKE_INSTALL_BINDIR}/licenses
+)
+install(FILES ${PROJECT_SOURCE_DIR}/Converter/libs/json/LICENSE
+	RENAME license_json.txt
+	DESTINATION ${CMAKE_INSTALL_BINDIR}/licenses
+)
+
+include(CPack)
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/licenses/license_potree_converter.txt")
+set(CPACK_RESOURCE_FILE_README "${PROJECT_SOURCE_DIR}/README.md")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ add_executable(PotreeConverter
 	${HEADER_FILES}
 )
 
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
+	target_compile_options(${PROJECT_NAME} PRIVATE /MP)
+endif()
+
 set(LASZIP_DIR "${PROJECT_SOURCE_DIR}/Converter/libs/laszip")
 add_subdirectory(${LASZIP_DIR})
 target_link_libraries(PotreeConverter laszip)

--- a/Converter/include/PotreeConverter.h
+++ b/Converter/include/PotreeConverter.h
@@ -207,8 +207,7 @@ inline Attributes computeOutputAttributes(vector<Source>& sources, vector<string
 	// compute scale and offset from all sources
 	{
 		mutex mtx;
-		auto parallel = std::execution::par;
-		for_each(parallel, sources.begin(), sources.end(), [&mtx, &sources, &scaleMin, &min, &max, requestedAttributes, &fullAttributeList, &acceptedAttributeNames](Source source) {
+		for_each(std::execution::par, sources.begin(), sources.end(), [&mtx, &sources, &scaleMin, &min, &max, requestedAttributes, &fullAttributeList, &acceptedAttributeNames](Source source) {
 
 			auto header = loadLasHeader(source.path);
 

--- a/Converter/include/sampler_poisson.h
+++ b/Converter/include/sampler_poisson.h
@@ -79,7 +79,7 @@ struct SamplerPoisson : public Sampler {
 			vector<int64_t> numRejectedPerChild(8, 0);
 			int64_t numAccepted = 0;
 
-			for (int64_t childIndex = 0; childIndex < 8; childIndex++) {
+			for (int32_t childIndex = 0; childIndex < 8; childIndex++) {
 				auto child = node->children[childIndex];
 
 				if (child == nullptr) {
@@ -92,8 +92,8 @@ struct SamplerPoisson : public Sampler {
 				vector<int8_t> acceptedFlags(child->numPoints, 0);
 				acceptedChildPointFlags.push_back(acceptedFlags);
 
-				for (int64_t i = 0; i < child->numPoints; i++) {
-					int64_t pointOffset = i * attributes.bytes;
+				for (int32_t i = 0; i < child->numPoints; i++) {
+					int64_t pointOffset = (int64_t)i * attributes.bytes;
 					int32_t* xyz = reinterpret_cast<int32_t*>(child->points->data_u8 + pointOffset);
 
 					double x = (xyz[0] * scale.x) + offset.x;

--- a/Converter/include/sampler_poisson.h
+++ b/Converter/include/sampler_poisson.h
@@ -179,8 +179,7 @@ struct SamplerPoisson : public Sampler {
 
 			};
 
-			auto parallel = std::execution::par_unseq;
-			std::sort(parallel, points.begin(), points.end(), [center](Point a, Point b) -> bool {
+			std::sort(std::execution::par_unseq, points.begin(), points.end(), [center](Point a, Point b) -> bool {
 
 				auto ax = a.x - center.x;
 				auto ay = a.y - center.y;

--- a/Converter/include/sampler_poisson_average.h
+++ b/Converter/include/sampler_poisson_average.h
@@ -280,8 +280,7 @@ struct SamplerPoissonAverage : public Sampler {
 
 			};
 
-			auto parallel = std::execution::par_unseq;
-			std::sort(parallel, points.begin(), points.end(), [center](Point a, Point b) -> bool {
+			std::sort(std::execution::par_unseq, points.begin(), points.end(), [center](Point a, Point b) -> bool {
 
 				auto ax = a.x - center.x;
 				auto ay = a.y - center.y;

--- a/Converter/libs/brotli/CMakeLists.txt
+++ b/Converter/libs/brotli/CMakeLists.txt
@@ -1,9 +1,3 @@
-# Ubuntu 12.04 LTS has CMake 2.8.7, and is an important target since
-# several CI services, such as Travis and Drone, use it.  Solaris 11
-# has 2.8.6, and it's not difficult to support if you already have to
-# support 2.8.7.
-cmake_minimum_required(VERSION 2.8.6)
-
 project(brotli C)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/Converter/libs/laszip/CMakeLists.txt
+++ b/Converter/libs/laszip/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
 set(CMAKE_SUPPRESS_REGENERATION true)
 
 project(LASzip LANGUAGES CXX)

--- a/Converter/libs/laszip/src/mydefs.hpp
+++ b/Converter/libs/laszip/src/mydefs.hpp
@@ -95,7 +95,7 @@ typedef union I64U32I32F32 { I64 i64; U32 u32[2]; I32 i32[2]; F32 f32[2]; } I64U
 #define U32_MIN            ((U32)0x0)            // 0
 #define U32_MAX            ((U32)0xFFFFFFFF)     // 4294967295
 #define U32_MAX_MINUS_ONE  ((U32)0xFFFFFFFE)     // 4294967294
-#if defined(WIN32)            // 64 byte unsigned int constant under Windows 
+#if defined(_WIN32)            // 64 byte unsigned int constant under Windows 
 #define U32_MAX_PLUS_ONE   0x0000000100000000    // 4294967296
 #else                         // 64 byte unsigned int constant elsewhere ... 
 #define U32_MAX_PLUS_ONE   0x0000000100000000ull // 4294967296

--- a/Converter/modules/unsuck/unsuck.hpp
+++ b/Converter/modules/unsuck/unsuck.hpp
@@ -41,7 +41,7 @@ static double Infinity = std::numeric_limits<double>::infinity();
 
 #if defined(__linux__)
 constexpr auto fseek_64_all_platforms = fseeko64;
-#elif defined(WIN32)
+#elif defined(_WIN32)
 constexpr auto fseek_64_all_platforms = _fseeki64;
 #endif
 

--- a/Converter/modules/unsuck/unsuck.hpp
+++ b/Converter/modules/unsuck/unsuck.hpp
@@ -39,10 +39,12 @@ static long long unsuck_start_time = high_resolution_clock::now().time_since_epo
 static double Infinity = std::numeric_limits<double>::infinity();
 
 
-#if defined(__linux__)
-constexpr auto fseek_64_all_platforms = fseeko64;
+#if (LONG_MAX == INT64_MAX)
+constexpr auto fseek_64_all_platforms = &fseek;
 #elif defined(_WIN32)
 inline const auto fseek_64_all_platforms = &_fseeki64;
+#else // e.g. LP32
+constexpr auto fseek_64_all_platforms = &fseeko64;
 #endif
 
 

--- a/Converter/modules/unsuck/unsuck.hpp
+++ b/Converter/modules/unsuck/unsuck.hpp
@@ -42,7 +42,7 @@ static double Infinity = std::numeric_limits<double>::infinity();
 #if defined(__linux__)
 constexpr auto fseek_64_all_platforms = fseeko64;
 #elif defined(_WIN32)
-constexpr auto fseek_64_all_platforms = _fseeki64;
+inline const auto fseek_64_all_platforms = &_fseeki64;
 #endif
 
 

--- a/Converter/modules/unsuck/unsuck_platform_specific.cpp
+++ b/Converter/modules/unsuck/unsuck_platform_specific.cpp
@@ -1,5 +1,38 @@
-
 #include "unsuck.hpp"
+
+#include <cstdint>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+void printMemoryReport() {
+	static constexpr auto gb = 1024.0 * 1024.0 * 1024.0;
+	const auto memoryData = getMemoryData();
+	const auto vm = double(memoryData.virtual_usedByProcess) / gb;
+	const auto pm = double(memoryData.physical_usedByProcess) / gb;
+
+	std::cout
+		<< "memory usage: "
+		<< "virtual: " << formatNumber(vm, 1) << " GB, "
+		<< "physical: " << formatNumber(pm, 1) << " GB"
+		<< std::endl;
+}
+
+void launchMemoryChecker(int64_t maxMB, double checkInterval) {
+	const auto interval = std::chrono::milliseconds(int64_t(checkInterval * 1000));
+
+	std::thread([maxMB, interval]() {
+		static constexpr double lastReport = 0.0;
+		static constexpr double reportInterval = 1.0;
+		static constexpr double lastUsage = 0.0;
+		static constexpr double largestUsage = 0.0;
+
+		while (true) {
+			auto memdata = getMemoryData();
+			std::this_thread::sleep_for(interval);
+		}
+	}).detach();
+}
 
 #ifdef _WIN32
 	#include "TCHAR.h"
@@ -51,45 +84,6 @@ MemoryData getMemoryData() {
 	return data;
 }
 
-
-void printMemoryReport() {
-
-	auto memoryData = getMemoryData();
-	double vm = double(memoryData.virtual_usedByProcess) / (1024.0 * 1024.0 * 1024.0);
-	double pm = double(memoryData.physical_usedByProcess) / (1024.0 * 1024.0 * 1024.0);
-
-	stringstream ss;
-	ss << "memory usage: "
-		<< "virtual: " << formatNumber(vm, 1) << " GB, "
-		<< "physical: " << formatNumber(pm, 1) << " GB"
-		<< endl;
-
-	cout << ss.str();
-
-}
-
-void launchMemoryChecker(int64_t maxMB, double checkInterval) {
-
-	auto interval = std::chrono::milliseconds(int64_t(checkInterval * 1000));
-
-	thread t([maxMB, interval]() {
-
-		static double lastReport = 0.0;
-		static double reportInterval = 1.0;
-		static double lastUsage = 0.0;
-		static double largestUsage = 0.0;
-
-		while (true) {
-			auto memdata = getMemoryData();
-
-			using namespace std::chrono_literals;
-			std::this_thread::sleep_for(interval);
-		}
-
-	});
-	t.detach();
-
-}
 
 static ULARGE_INTEGER lastCPU, lastSysCPU, lastUserCPU;
 static int numProcessors;
@@ -258,45 +252,6 @@ MemoryData getMemoryData() {
 	return data;
 }
 
-
-void printMemoryReport() {
-
-	auto memoryData = getMemoryData();
-	double vm = double(memoryData.virtual_usedByProcess) / (1024.0 * 1024.0 * 1024.0);
-	double pm = double(memoryData.physical_usedByProcess) / (1024.0 * 1024.0 * 1024.0);
-
-	stringstream ss;
-	ss << "memory usage: "
-		<< "virtual: " << formatNumber(vm, 1) << " GB, "
-		<< "physical: " << formatNumber(pm, 1) << " GB"
-		<< endl;
-
-	cout << ss.str();
-
-}
-
-void launchMemoryChecker(int64_t maxMB, double checkInterval) {
-
-	auto interval = std::chrono::milliseconds(int64_t(checkInterval * 1000));
-
-	thread t([maxMB, interval]() {
-
-		static double lastReport = 0.0;
-		static double reportInterval = 1.0;
-		static double lastUsage = 0.0;
-		static double largestUsage = 0.0;
-
-		while (true) {
-			auto memdata = getMemoryData();
-
-			using namespace std::chrono_literals;
-			std::this_thread::sleep_for(interval);
-		}
-
-	});
-	t.detach();
-
-}
 
 static int numProcessors;
 static bool initialized = false;

--- a/Converter/modules/unsuck/unsuck_platform_specific.cpp
+++ b/Converter/modules/unsuck/unsuck_platform_specific.cpp
@@ -1,7 +1,9 @@
 #include "unsuck.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <chrono>
+#include <algorithm>
 #include <iostream>
 #include <thread>
 
@@ -311,5 +313,173 @@ CpuData getCpuData() {
 	return data;
 }
 
+#elif defined(__APPLE__) && defined(__MACH__)
+
+#include <mach/host_info.h>
+#include <mach/kern_return.h>
+#include <mach/mach.h>
+#include <mach/mach_host.h>
+#include <mach/mach_init.h>
+#include <mach/mach_port.h>
+#include <mach/mach_vm.h>
+#include <mach/machine.h>
+#include <mach/message.h>
+#include <mach/port.h>
+#include <mach/shared_region.h>
+#include <mach/task.h>
+#include <mach/task_info.h>
+#include <mach/vm_prot.h>
+#include <mach/vm_region.h>
+#include <mach/vm_statistics.h>
+#include <sys/sysctl.h>
+#include <unistd.h>
+
+namespace {
+
+struct MachPort {
+	mach_port_t port;
+
+	~MachPort() {
+		if (port != MACH_PORT_NULL) {
+			mach_port_deallocate(mach_task_self(), port);
+		}
+	}
+};
+
+auto getMachHostPort() {
+	static auto machHost = MachPort{ mach_host_self() };
+	return machHost.port;
+}
+
+} // namespace
+
+MemoryData getMemoryData() {
+	const auto pageSize = sysconf(_SC_PAGESIZE);
+	if (pageSize < 0) {
+		return {};
+	}
+
+	MemoryData data;
+
+	{
+		size_t physMem = 0;
+		auto length = sizeof(physMem);
+		int mib[2] = { CTL_HW, HW_MEMSIZE };
+		if (sysctl(mib, 2, &physMem, &length, nullptr, 0) == 0) {
+			data.physical_total = physMem;
+		}
+	}
+	{
+		xsw_usage vmusage;
+		size_t size = sizeof(vmusage);
+		int mib[2] = { CTL_VM, VM_SWAPUSAGE };
+		if (sysctl(mib, 2, &vmusage, &size, nullptr, 0) == 0) {
+			data.virtual_used = vmusage.xsu_used;
+			
+			// Note: Unlike most UNIX-based operating systems, OS X does not use a preallocated disk partition for the backing store. Instead, it uses all of the available space on the machine’s boot partition.
+			// https://developer.apple.com/library/archive/documentation/Performance/Conceptual/ManagingMemory/Articles/AboutMemory.html
+			// https://superuser.com/questions/1396826/macos-virtual-memory-limit-architectural-or-practical
+			data.virtual_total = vmusage.xsu_total;
+		}
+	}
+	auto count = HOST_VM_INFO_COUNT;
+	vm_statistics_data_t vm_stat;
+	if (host_statistics(getMachHostPort(), HOST_VM_INFO, (host_info_t)&vm_stat, &count)
+		== KERN_SUCCESS)
+	{
+		const auto usedMem =
+			((size_t)vm_stat.active_count + vm_stat.inactive_count + vm_stat.wire_count) * pageSize;
+		// const auto freeMem = vm_stat.free_count * (size_t)pageSize;
+
+		data.physical_used = usedMem;
+	}
+	{
+		mach_task_basic_info info;
+		mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;
+		if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info, &infoCount)
+			== KERN_SUCCESS) {
+			data.physical_usedByProcess = info.resident_size;
+		}
+	}
+	{ // https://stackoverflow.com/questions/78815207/why-is-virtual-size-on-macos-so-different-from-vmsize-on-linux
+		const auto isSharedRegion = [](mach_vm_address_t address) {
+			return address >= SHARED_REGION_BASE && address < (SHARED_REGION_BASE + SHARED_REGION_SIZE);
+		};
+
+		mach_vm_address_t address = 0;
+		size_t sum = 0;
+		size_t sharedSum = 0;
+		mach_vm_size_t vmsize = 0;
+		vm_region_basic_info_data_64_t info;
+		while (true) {
+			auto infoCount = VM_REGION_BASIC_INFO_COUNT_64;
+			MachPort objName;
+			if (mach_vm_region(mach_task_self(), &address, &vmsize, VM_REGION_BASIC_INFO_64, (vm_region_info_t)&info, &infoCount, &objName.port)
+				!= KERN_SUCCESS) {
+				break;
+			}
+
+			if (info.protection == VM_PROT_NONE) {
+				address += vmsize;
+				continue;
+			}
+
+			if (isSharedRegion(address)) {
+				sharedSum += vmsize;
+			}
+			address += vmsize;
+			sum += vmsize;
+		}
+		data.virtual_usedByProcess = sum - sharedSum;
+	}
+
+	static size_t physicalUsedMax = 0;
+	static size_t virtualUsedMax = 0;
+	physicalUsedMax = std::max(data.physical_usedByProcess, physicalUsedMax);
+	virtualUsedMax = std::max(data.virtual_usedByProcess, virtualUsedMax);
+	data.physical_usedByProcess_max = physicalUsedMax;
+	data.virtual_usedByProcess_max = virtualUsedMax;
+
+	return data;
+}
+
+CpuData getCpuData() {
+	static auto numProcessors = std::thread::hardware_concurrency();
+
+	CpuData data;
+	data.numProcessors = numProcessors;
+
+	struct CPULoadState {
+		size_t prevTotalTicks = 0;
+		size_t prevIdleTicks = 0;
+	};
+	static CPULoadState state;
+
+	host_cpu_load_info_data_t cpuInfo;
+	auto count = HOST_CPU_LOAD_INFO_COUNT;
+	if (host_statistics(getMachHostPort(), HOST_CPU_LOAD_INFO, (host_info_t)&cpuInfo, &count)
+		!= KERN_SUCCESS)
+	{
+		data.usage = NAN;
+		return data;
+	}
+
+	size_t totalTicks = 0;
+	for (uint32_t i = 0; i < CPU_STATE_MAX; ++i)
+	{
+		totalTicks += cpuInfo.cpu_ticks[i];
+	}
+	const auto idleTicks = cpuInfo.cpu_ticks[CPU_STATE_IDLE];
+
+	const auto totalTicksSinceLast = totalTicks - state.prevTotalTicks;
+	const auto idleTicksSinceLast = idleTicks - state.prevIdleTicks;
+
+	data.usage = (1.0 - ((double)idleTicksSinceLast / (double)totalTicksSinceLast)) * 100.0;
+
+	state.prevTotalTicks = totalTicks;
+	state.prevIdleTicks = idleTicks;
+
+	return data;
+}
 
 #endif

--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -279,8 +279,7 @@ namespace chunker_countsort_laszip {
 		auto tStartTaskAssembly = now();
 
 		for (auto source : sources) {
-		//auto parallel = std::execution::par;
-		//for_each(parallel, paths.begin(), paths.end(), [&mtx, &sources](string path) {
+		//for_each(std::execution::par, paths.begin(), paths.end(), [&mtx, &sources](string path) {
 
 			laszip_POINTER laszip_reader;
 			laszip_header* header;

--- a/Converter/src/main.cpp
+++ b/Converter/src/main.cpp
@@ -180,8 +180,7 @@ Curated curateSources(vector<string> paths) {
 	sources.reserve(paths.size());
 
 	mutex mtx;
-	auto parallel = std::execution::par;
-	for_each(parallel, paths.begin(), paths.end(), [&mtx, &sources](string path) {
+	for_each(std::execution::par, paths.begin(), paths.end(), [&mtx, &sources](string path) {
 
 		auto header = loadLasHeader(path);
 		auto filesize = fs::file_size(path);

--- a/README.md
+++ b/README.md
@@ -22,17 +22,11 @@ Altough the converter made a major step to version 2.0, the format it produces i
 1. Download windows binaries or
     * Download source code
 	* Install [CMake](https://cmake.org/) 3.16 or later
-	* Create and jump into folder "build"
+	* run
+	    ```shell
+	    cmake -B build # -G "Ninja Multi-Config" # Use Ninja to parallelize building
+	    cmake --build build --config Release
 	    ```
-	    mkdir build
-	    cd build
-	    ```
-	* run 
-	    ```
-	    cmake ../
-	    ```
-	* On linux, run: ```make```
-	* On windows, open Visual Studio 2019 Project ./Converter/Converter.sln and compile it in release mode
 2. run ```PotreeConverter.exe <input> -o <outputDir>```
     * Optionally specify the sampling strategy:
 	* Poisson-disk sampling (default): ```PotreeConverter.exe <input> -o <outputDir> -m poisson```


### PR DESCRIPTION
fix: 
- #444 
- #664 
- #689 

Primary changes:
1. Fixed the use of `parallel algorithm` for libc++ (used on `Android` and `macOS`).
2. Hardware monitor support for macOS.
3. Standardized the use of `fseek*` across all platforms, favoring the C standard `fseek` where possible (`fseeko64` is unavailable on macOS).

Additional updates:
1. Resolved some narrowing conversion warnings.
2. Adopted standard predefined macros (`_WIN32`).
4. Addressed the non-constant `fseek_64_all_platforms` on Windows (the address of `_fseeki64` is not a link-time constant, declared as `__declspec(dllimport)`, which is rejected by `clang-cl`).
5. Updated building tutorial in `ReadMe`
6. `/MP` for MSBuild (to accelerate building)
7. CPack support

References (noted in commit messages):
- https://github.com/cpredef/predef/blob/master/OperatingSystems.md#windows
- https://libcxx.llvm.org/Status/PSTL.html
- https://github.com/llvm/llvm-project/blob/5a86dc996c26299de63effc927075dcbfb924167/libcxx/include/execution#L54C61-L54C94
- https://stackoverflow.com/questions/34388466/what-is-the-best-way-to-seek-past-2gib-in-c
- https://stackoverflow.com/questions/78815207/why-is-virtual-size-on-macos-so-different-from-vmsize-on-linux