### PR TITLE
Fix incorrect offset calculation when writing extra attributes to output buffer

### DIFF
--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -1,4 +1,3 @@
-
 #include <iostream>
 #include <filesystem>
 #include <unordered_map>
@@ -584,8 +583,8 @@ namespace chunker_countsort_laszip {
 				int attributeSize = inputAttribute.size;
 
 				if (attribute != nullptr) {
-					auto handleAttribute = [data, point, header, attributeSize, attributeOffset, sourceOffset, attribute](int64_t offset) {
-						memcpy(data + offset + attributeOffset, point->extra_bytes + sourceOffset, attributeSize);
+					auto handleAttribute = [data, point, header, attributeSize, targetOffset, sourceOffset, attribute](int64_t offset) {
+						memcpy(data + offset + targetOffset, point->extra_bytes + sourceOffset, attributeSize);
 
 						std::function<double(uint8_t*)> f;
 


### PR DESCRIPTION
  Problem:
  When writing extra attributes from LAS files to the output buffer, the code incorrectly uses attributeOffset (which tracks the input attribute positions) instead of
  targetOffset (which represents the correct output buffer offset).

  This causes extra attributes to be written to wrong memory locations in the output buffer, resulting in corrupted point cloud data when the input and output attribute layouts
  differ.

  Root Cause:
  In chunker_countsort_laszip.cpp, the lambda capture and memcpy operation use attributeOffset:
  auto handleAttribute = [data, point, header, attributeSize, attributeOffset, sourceOffset, attribute](int64_t offset) {
      memcpy(data + offset + attributeOffset, point->extra_bytes + sourceOffset, attributeSize);

  However, targetOffset is already correctly calculated on line 582 using outputAttributes.getOffset() but was never used.

  Fix:
  Replace attributeOffset with targetOffset in the lambda capture and memcpy call:
  auto handleAttribute = [data, point, header, attributeSize, targetOffset, sourceOffset, attribute](int64_t offset) {
      memcpy(data + offset + targetOffset, point->extra_bytes + sourceOffset, attributeSize);