### PR TITLE
Add --chunk-dir option to configure the temporary chunk directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
-
+.idea
 Converter/bin
 Converter/.vs
 Converter/obj
 Converter.vcxproj.user
 nocommit
 build
+build-*/
+dist/
+dist-*/
+*.laz

--- a/Converter/include/chunker_countsort_laszip.h
+++ b/Converter/include/chunker_countsort_laszip.h
@@ -16,6 +16,6 @@ class State;
 
 namespace chunker_countsort_laszip {
 
-	void doChunking(vector<Source> sources, string targetDir, Vector3 min, Vector3 max, State& state, Attributes outputAttributes, Monitor* monitor);
+	void doChunking(vector<Source> sources, string chunkDir, Vector3 min, Vector3 max, State& state, Attributes outputAttributes, Monitor* monitor);
 
 }

--- a/Converter/include/converter_utils.h
+++ b/Converter/include/converter_utils.h
@@ -160,6 +160,7 @@ struct Options {
 	vector<string> source;
 	string encoding = "DEFAULT"; // "BROTLI", "UNCOMPRESSED"
 	string outdir = "";
+	string chunkDir = ""; // if empty, defaults to "<outdir>/chunks"
 	string name = "";
 	string method = "";
 	string chunkMethod = "";

--- a/Converter/include/indexer.h
+++ b/Converter/include/indexer.h
@@ -78,7 +78,7 @@ namespace indexer{
 
 	};
 
-	shared_ptr<Chunks> getChunks(string pathIn);
+	shared_ptr<Chunks> getChunks(string chunkDir);
 
 	
 
@@ -376,7 +376,7 @@ namespace indexer{
 		string do_grouping() const { return "\3"; }
 	};
 
-	void doIndexing(string targetDir, State& state, Options& options, Sampler& sampler);
+	void doIndexing(string targetDir, string chunkDir, State& state, Options& options, Sampler& sampler);
 
 
 }

--- a/Converter/modules/unsuck/unsuck_platform_specific.cpp
+++ b/Converter/modules/unsuck/unsuck_platform_specific.cpp
@@ -38,8 +38,8 @@ MemoryData getMemoryData() {
 		static size_t virtualUsedMax = 0;
 		static size_t physicalUsedMax = 0;
 
-		virtualUsedMax = max(virtualMemUsedByMe, virtualUsedMax);
-		physicalUsedMax = max(physMemUsedByMe, physicalUsedMax);
+		virtualUsedMax = (std::max)(virtualMemUsedByMe, virtualUsedMax);
+		physicalUsedMax = (std::max)(physMemUsedByMe, physicalUsedMax);
 
 		data.virtual_usedByProcess = virtualMemUsedByMe;
 		data.virtual_usedByProcess_max = virtualUsedMax;

--- a/Converter/src/chunker_countsort_laszip.cpp
+++ b/Converter/src/chunker_countsort_laszip.cpp
@@ -360,7 +360,7 @@ namespace chunker_countsort_laszip {
 		return std::move(grid);
 	}
 
-	void addBuckets(string targetDir, vector<shared_ptr<Buffer>>& newBuckets) {
+	void addBuckets(string chunkDir, vector<shared_ptr<Buffer>>& newBuckets) {
 
 		for(int nodeIndex = 0; nodeIndex < nodes.size(); nodeIndex++){
 
@@ -369,7 +369,7 @@ namespace chunker_countsort_laszip {
 			}
 
 			auto& node = nodes[nodeIndex];
-			string path = targetDir + "/chunks/" + node.id + ".bin";
+			string path = chunkDir + "/" + node.id + ".bin";
 			auto buffer = newBuckets[nodeIndex];
 
 			writer->write(path, buffer);
@@ -670,7 +670,7 @@ namespace chunker_countsort_laszip {
 
 	}
 
-	void distributePoints(vector<Source> sources, Vector3 min, Vector3 max, string targetDir, NodeLUT& lut, State& state, Attributes& outputAttributes, Monitor* monitor) {
+	void distributePoints(vector<Source> sources, Vector3 min, Vector3 max, string chunkDir, NodeLUT& lut, State& state, Attributes& outputAttributes, Monitor* monitor) {
 
 		cout << endl;
 		cout << "=======================================" << endl;
@@ -706,7 +706,7 @@ namespace chunker_countsort_laszip {
 
 		printElapsedTime("distributePoints1", tStart);
 
-		auto processor = [&mtx_push_point, &counters, targetDir, &state, tStart, &outputAttributes](shared_ptr<Task> task) {
+		auto processor = [&mtx_push_point, &counters, chunkDir, &state, tStart, &outputAttributes](shared_ptr<Task> task) {
 
 			auto path = task->path;
 			auto batchSize = task->batchSize;
@@ -921,7 +921,7 @@ namespace chunker_countsort_laszip {
 			state.duration = now() - tStart;
 
 			auto tAddBuckets = now();
-			addBuckets(targetDir, buckets);
+			addBuckets(chunkDir, buckets);
 
 			// merge attribute metadata of this batch into global attribute metadata
 			for (int i = 0; i < outputAttributesCopy.list.size(); i++) {
@@ -1216,7 +1216,7 @@ namespace chunker_countsort_laszip {
 		return {gridSize, lut};
 	}
 
-	void doChunking(vector<Source> sources, string targetDir, Vector3 min, Vector3 max, State& state, Attributes outputAttributes, Monitor* monitor) {
+	void doChunking(vector<Source> sources, string chunkDir, Vector3 min, Vector3 max, State& state, Attributes outputAttributes, Monitor* monitor) {
 
 		auto tStart = now();
 
@@ -1235,10 +1235,9 @@ namespace chunker_countsort_laszip {
 		state.currentPass = 1;
 
 		{ // prepare/clean target directories
-			string dir = targetDir + "/chunks";
-			fs::create_directories(dir);
+			fs::create_directories(chunkDir);
 
-			for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+			for (const auto& entry : std::filesystem::directory_iterator(chunkDir)) {
 				std::filesystem::remove(entry);
 			}
 		}
@@ -1252,16 +1251,16 @@ namespace chunker_countsort_laszip {
 			auto lut = createLUT(grid, gridSize);
 
 			state.currentPass = 2;
-			distributePoints(sources, min, max, targetDir, lut, state, outputAttributes, monitor);
+			distributePoints(sources, min, max, chunkDir, lut, state, outputAttributes, monitor);
 
 			{
 				double duration = now() - tStartDistribute;
 				state.values["duration(chunking-distribute)"] = formatNumber(duration, 3);
 			}
 		}
-		
 
-		string metadataPath = targetDir + "/chunks/metadata.json";
+
+		string metadataPath = chunkDir + "/metadata.json";
 		double cubeSize = (max - min).max();
 		Vector3 size = { cubeSize, cubeSize, cubeSize };
 		max = min + cubeSize;

--- a/Converter/src/indexer.cpp
+++ b/Converter/src/indexer.cpp
@@ -50,8 +50,7 @@ namespace indexer{
 		return mask;
 	}
 
-	shared_ptr<Chunks> getChunks(string pathIn) {
-		string chunkDirectory = pathIn + "/chunks";
+	shared_ptr<Chunks> getChunks(string chunkDirectory) {
 
 		string metadataText = readTextFile(chunkDirectory + "/metadata.json");
 		json js = json::parse(metadataText);
@@ -1578,7 +1577,7 @@ void Writer::closeAndWait() {
 
 
 
-void doIndexing(string targetDir, State& state, Options& options, Sampler& sampler) {
+void doIndexing(string targetDir, string chunkDir, State& state, Options& options, Sampler& sampler) {
 
 	cout << endl;
 	cout << "=======================================" << endl;
@@ -1593,7 +1592,7 @@ void doIndexing(string targetDir, State& state, Options& options, Sampler& sampl
 	state.bytesProcessed = 0;
 	state.duration = 0;
 
-	auto chunks = getChunks(targetDir);
+	auto chunks = getChunks(chunkDir);
 	auto attributes = chunks->attributes;
 
 	Indexer indexer(targetDir);
@@ -1777,10 +1776,10 @@ void doIndexing(string targetDir, State& state, Options& options, Sampler& sampl
 
 		// delete chunk directory
 		if (!options.keepChunks) {
-			string chunksMetadataPath = targetDir + "/chunks/metadata.json";
+			string chunksMetadataPath = chunkDir + "/metadata.json";
 
 			fs::remove(chunksMetadataPath);
-			fs::remove(targetDir + "/chunks");
+			fs::remove(chunkDir);
 		}
 
 		// delete chunk roots data

--- a/Converter/src/main.cpp
+++ b/Converter/src/main.cpp
@@ -24,6 +24,7 @@ Options parseArguments(int argc, char** argv) {
 	args.addArgument("source,i,", "Input file(s)");
 	args.addArgument("help,h", "Display help information");
 	args.addArgument("outdir,o", "Output directory");
+	args.addArgument("chunk-dir", "Directory for temporary chunks (default: <outdir>/chunks)");
 	args.addArgument("encoding", "Encoding type \"BROTLI\", \"UNCOMPRESSED\" (default)");
 	args.addArgument("method,m", "Point sampling method \"poisson\", \"poisson_average\", \"random\"");
 	args.addArgument("chunkMethod", "Chunking method");
@@ -102,6 +103,12 @@ Options parseArguments(int argc, char** argv) {
 
 	outdir = fs::weakly_canonical(fs::path(outdir)).string();
 
+	string chunkDir = "";
+	if (args.has("chunk-dir")) {
+		chunkDir = args.get("chunk-dir").as<string>();
+		chunkDir = fs::weakly_canonical(fs::path(chunkDir)).string();
+	}
+
 	//vector<string> flags = args.get("flags").as<vector<string>>();
 
 	vector<string> attributes = args.get("attributes").as<vector<string>>();
@@ -121,6 +128,7 @@ Options parseArguments(int argc, char** argv) {
 	Options options;
 	options.source = source;
 	options.outdir = outdir;
+	options.chunkDir = chunkDir;
 	options.method = method;
 	options.encoding = encoding;
 	options.chunkMethod = chunkMethod;
@@ -342,7 +350,7 @@ Stats computeStats(vector<Source> sources){
 // }
 
 
-void chunking(Options& options, vector<Source>& sources, string targetDir, Stats& stats, State& state, Attributes outputAttributes, Monitor* monitor) {
+void chunking(Options& options, vector<Source>& sources, string chunkDir, Stats& stats, State& state, Attributes outputAttributes, Monitor* monitor) {
 
 	if (options.noChunking) {
 		return;
@@ -350,7 +358,7 @@ void chunking(Options& options, vector<Source>& sources, string targetDir, Stats
 
 	if (options.chunkMethod == "LASZIP") {
 
-		chunker_countsort_laszip::doChunking(sources, targetDir, stats.min, stats.max, state, outputAttributes, monitor);
+		chunker_countsort_laszip::doChunking(sources, chunkDir, stats.min, stats.max, state, outputAttributes, monitor);
 
 	} else if (options.chunkMethod == "LAS_CUSTOM") {
 
@@ -368,7 +376,7 @@ void chunking(Options& options, vector<Source>& sources, string targetDir, Stats
 	}
 }
 
-void indexing(Options& options, string targetDir, State& state) {
+void indexing(Options& options, string targetDir, string chunkDir, State& state) {
 
 	if (options.noIndexing) {
 		return;
@@ -377,17 +385,17 @@ void indexing(Options& options, string targetDir, State& state) {
 	if (options.method == "random") {
 
 		SamplerRandom sampler;
-		indexer::doIndexing(targetDir, state, options, sampler);
+		indexer::doIndexing(targetDir, chunkDir, state, options, sampler);
 
 	} else if (options.method == "poisson") {
 
 		SamplerPoisson sampler;
-		indexer::doIndexing(targetDir, state, options, sampler);
+		indexer::doIndexing(targetDir, chunkDir, state, options, sampler);
 
 	} else if (options.method == "poisson_average") {
 
 		SamplerPoissonAverage sampler;
-		indexer::doIndexing(targetDir, state, options, sampler);
+		indexer::doIndexing(targetDir, chunkDir, state, options, sampler);
 
 	}
 }
@@ -543,6 +551,9 @@ int main(int argc, char** argv) {
 	fs::create_directories(targetDir);
 	logger::addOutputFile(targetDir + "/log.txt");
 
+	string chunkDir = options.chunkDir.size() > 0 ? options.chunkDir : (targetDir + "/chunks");
+	cout << "chunk directory: '" << chunkDir << "'" << endl;
+
 	State state;
 	state.pointsTotal = stats.totalPoints;
 	state.bytesProcessed = stats.totalBytes;
@@ -554,9 +565,9 @@ int main(int argc, char** argv) {
 
 	{ // this is the real important stuff
 
-		chunking(options, sources, targetDir, stats, state, outputAttributes, monitor.get());
+		chunking(options, sources, chunkDir, stats, state, outputAttributes, monitor.get());
 
-		indexing(options, targetDir, state);
+		indexing(options, targetDir, chunkDir, state);
 
 	}
 


### PR DESCRIPTION
## Summary
- Adds a `--chunk-dir` CLI option so the temporary chunk directory can be pointed anywhere instead of being hardcoded to `<outdir>/chunks`.
- Defaults to `<outdir>/chunks` when not specified, preserving existing behavior.

## Test plan
- [x] Built in a Docker container (Ubuntu 24.04, gcc 13) since no local C++ toolchain was available.
- [x] Ran `--help` to confirm the new flag is listed.
- [x] Converted a real `.laz` (1.49M points) with `--chunk-dir` pointing outside `outdir` and `--keep-chunks`; verified chunk files land in the custom directory and final octree/hierarchy/metadata land in `outdir`.
- [x] Verified default behavior (no `--chunk-dir`) still creates and cleans up `<outdir>/chunks` as before.
- [x] Verified `--chunk-dir` combined with `--encoding BROTLI` works correctly.